### PR TITLE
#145 - Update JSON deserialization configuration

### DIFF
--- a/exploration-module/src/main/java/io/edpn/backend/exploration/adapter/config/BeanConfig.java
+++ b/exploration-module/src/main/java/io/edpn/backend/exploration/adapter/config/BeanConfig.java
@@ -1,7 +1,9 @@
 package io.edpn.backend.exploration.adapter.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.edpn.backend.util.IdGenerator;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
@@ -11,6 +13,9 @@ import org.springframework.retry.support.RetryTemplate;
 @Configuration("ExplorationModuleBeanConfig")
 public class BeanConfig {
 
+    @Value("${exploration.json.ignoreUnknownProperties:true}")
+    private boolean ignoreUnknownProperties;
+
     @Bean(name = "explorationIdGenerator")
     public IdGenerator idGenerator() {
         return new IdGenerator();
@@ -18,7 +23,9 @@ public class BeanConfig {
 
     @Bean(name = "explorationObjectMapper")
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, !ignoreUnknownProperties);
+        return mapper;
     }
 
     @Bean(name = "explorationRetryTemplate")

--- a/exploration-module/src/main/resources/explorationmodule-local.yaml
+++ b/exploration-module/src/main/resources/explorationmodule-local.yaml
@@ -12,3 +12,6 @@ exploration:
 
     kafka:
       bootstrap-servers: localhost:9092
+
+  json:
+    ignoreUnknownProperties: false

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/config/BeanConfig.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/config/BeanConfig.java
@@ -1,10 +1,12 @@
 package io.edpn.backend.trade.adapter.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.edpn.backend.util.IdGenerator;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -18,6 +20,8 @@ import java.time.format.DateTimeFormatter;
 @Configuration("TradeModuleBeanConfig")
 public class BeanConfig {
 
+    @Value("${trade.json.ignoreUnknownProperties:true}")
+    private boolean ignoreUnknownProperties;
 
     @Bean(name = "tradeIdGenerator")
     public IdGenerator idGenerator() {
@@ -31,6 +35,7 @@ public class BeanConfig {
         mapper.registerModule(new Jdk8Module());
         JavaTimeModule javaTimeModule = new JavaTimeModule();
         javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, !ignoreUnknownProperties);
         mapper.registerModule(javaTimeModule);
         return mapper;
     }

--- a/trade-module/src/main/resources/trademodule-local.yaml
+++ b/trade-module/src/main/resources/trademodule-local.yaml
@@ -13,3 +13,6 @@ trade:
 
     kafka:
       bootstrap-servers: localhost:9092
+
+  json:
+    ignoreUnknownProperties: false


### PR DESCRIPTION
The configuration for JSON deserialization across the Exploration and Trade modules has been updated. A configuration setting, `ignoreUnknownProperties`, has been added to the local .yaml files which determines how the system should handle unknown properties in the JSON. The ObjectMapper in each module's BeanConfig has been updated to use this new configuration setting.

closes #145 