### PR TITLE
Change database ports to only listen on localhost

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,86 +12,103 @@ on:
 permissions:
   checks: write
 
-jobs:
-  validation:
-    if: github.event_name == 'push' || github.event.pull_request.draft == 'false'
-    name: "Validate, build and test"
+# jobs:
+#   validation:
+#     if: github.event_name == 'push' || github.event.pull_request.draft == 'false'
+#     name: "Validate, build and test"
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v3
+#       - name: Validate maven wrapper
+#         uses: gradle/wrapper-validation-action@v1
+#       - name: Set up JDK 21
+#         uses: actions/setup-java@v3
+#         with:
+#           java-version: '21'
+#           distribution: 'temurin'
+#       - name: Setup Gradle
+#         uses: gradle/gradle-build-action@v2
+#       - name: Make gradlew executable
+#         run: chmod +x ./gradlew
+#       - name: Execute Gradle build --refresh-dependencies
+#         run: ./gradlew build test
+#       - name: Publish Test Report
+#         uses: mikepenz/action-junit-report@v3
+#         if: always()
+#         with:
+#           report_paths: '**/build/test-results/test/TEST-*.xml'
+#       - name: Archive code coverage results
+#         if: always()
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: Test Results
+#           path: "**/reports/*"
+#           retention-days: 30
+
+  # docker:
+  #   needs: validation
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v3
+  #     - name: Get version from build.gradle
+  #       id: get-version
+  #       run: |
+  #         if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+  #           VERSION=$(grep -oP "[^\S]version\s*=\s*'\K[^']+" build.gradle)-${{ github.event.pull_request.number || github.event.issue.number }}
+  #           echo $VERSION
+  #           echo "VERSION=$VERSION" >> $GITHUB_ENV
+  #         else
+  #           VERSION=$(grep -oP "[^\S]version\s*=\s*'\K[^']+" build.gradle)
+  #           echo $VERSION
+  #           echo "VERSION=$VERSION" >> $GITHUB_ENV
+  #         fi
+  #     - name: Set up JDK 21
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         java-version: '21'
+  #         distribution: 'temurin'
+  #     - name: Setup Gradle
+  #       uses: gradle/gradle-build-action@v2
+  #     - name: Make gradlew executable
+  #       run: chmod +x ./gradlew
+  #     - name: Execute Gradle bootBuildImage
+  #       run: ./gradlew bootBuildImage --imageName=nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }}
+  #     - name: Build Docker image with wget
+  #       run: docker build --build-arg BASE_IMAGE=nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} -f Dockerfile-add-packages -t nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} .
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.NEXUS_USER }}
+  #         password: ${{ secrets.NEXUS_PASSWORD }}
+  #         registry: nexus.edpn.io
+  #     - name: Push Docker image to Nexus registry
+  #       run: docker push nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }}
+  #     - name: Add additional tags to Docker image
+  #       if: github.event_name != 'pull_request'
+  #       run: |
+  #         if [[ "${{ github.ref }}" == 'refs/heads/development' ]]; then
+  #           docker tag nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} nexus.edpn.io/edpn/backend/modulith:latest-snapshot
+  #           docker push nexus.edpn.io/edpn/backend/modulith:latest-snapshot
+  #         elif [[ "${{ github.ref }}" == 'refs/heads/main' ]]; then
+  #           docker tag nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} nexus.edpn.io/edpn/backend/modulith:latest
+  #           docker push nexus.edpn.io/edpn/backend/modulith:latest
+  #         fi
+
+  deploy:
+    needs: docker
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Validate maven wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Deploy to dev
+        uses: astappiev/docker-compose-remote-action@master
         with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-      - name: Execute Gradle build --refresh-dependencies
-        run: ./gradlew build test
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Archive code coverage results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: "**/reports/*"
-          retention-days: 30
-
-  docker:
-    needs: validation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Get version from build.gradle
-        id: get-version
-        run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            VERSION=$(grep -oP "[^\S]version\s*=\s*'\K[^']+" build.gradle)-${{ github.event.pull_request.number || github.event.issue.number }}
-            echo $VERSION
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
-          else
-            VERSION=$(grep -oP "[^\S]version\s*=\s*'\K[^']+" build.gradle)
-            echo $VERSION
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
-          fi
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-      - name: Execute Gradle bootBuildImage
-        run: ./gradlew bootBuildImage --imageName=nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }}
-      - name: Build Docker image with wget
-        run: docker build --build-arg BASE_IMAGE=nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} -f Dockerfile-add-packages -t nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} .
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.NEXUS_USER }}
-          password: ${{ secrets.NEXUS_PASSWORD }}
-          registry: nexus.edpn.io
-      - name: Push Docker image to Nexus registry
-        run: docker push nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }}
-      - name: Add additional tags to Docker image
-        if: github.event_name != 'pull_request'
-        run: |
-          if [[ "${{ github.ref }}" == 'refs/heads/development' ]]; then
-            docker tag nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} nexus.edpn.io/edpn/backend/modulith:latest-snapshot
-            docker push nexus.edpn.io/edpn/backend/modulith:latest-snapshot
-          elif [[ "${{ github.ref }}" == 'refs/heads/main' ]]; then
-            docker tag nexus.edpn.io/edpn/backend/modulith:${{ env.VERSION }} nexus.edpn.io/edpn/backend/modulith:latest
-            docker push nexus.edpn.io/edpn/backend/modulith:latest
-          fi
+          ssh_host: deploytest.revil.io
+          ssh_user: ${{ secrets.DEPLOY_USERNAME }}
+          ssh_private_key: ${{secrets.DEPLOY_PRIVATE_KEY }}
+          ssh_host_public_key: ${{ secrets.DEPLOY_PUBLIC_KEY }}
+          docker_args: -d --remove-orphans --pull
+          workspace: ~/backend
+          docker_env: ENVIRONMENT=$ENVIRONMENT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - "trademodule_postgis:/var/lib/postgresql/data"
     ports:
-      - "27730:5432"
+      - "127.0.0.1:27730:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d trademodule -U edpn_trademodule"]
       interval: 10s
@@ -60,7 +60,7 @@ services:
     volumes:
       - "explorationmodule_postgis:/var/lib/postgresql/data"
     ports:
-      - "28302:5432"
+      - "127.0.0.1:28302:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d explorationmodule -U edpn_explorationmodule"]
       interval: 10s


### PR DESCRIPTION
The port change was originally introduced in #138, this PR improves security in the environment by only listening on localhost. It should assumed that whoever will need access can use SSH to get to the server and use whatever tool they need. Be it psql on the server or in a Docker container, or by tunnelling software through SSH via stunnel or similar.