### PR TITLE
153-Database-Connection-BugFix

### DIFF
--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/config/ServiceConfig.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/config/ServiceConfig.java
@@ -13,30 +13,30 @@ import io.edpn.backend.trade.application.port.outgoing.marketdatum.createOrUpdat
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.DeleteStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.ExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.LoadAllStationArrivalDistanceRequestsPort;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.DeleteSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.ExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.LoadAllSystemEliteIdRequestsPort;
@@ -111,7 +111,7 @@ public class ServiceConfig {
             CreateOrLoadSystemPort createOrLoadSystemPort,
             CreateOrLoadStationPort createOrLoadStationPort,
             ExistsStationArrivalDistanceRequestPort existsStationArrivalDistanceRequestPort,
-            CreateStationArrivalDistanceRequestPort createStationArrivalDistanceRequestPort,
+            CreateIfNotExistsStationArrivalDistanceRequestPort createIfNotExistsStationArrivalDistanceRequestPort,
             DeleteStationArrivalDistanceRequestPort deleteStationArrivalDistanceRequestPort,
             UpdateStationPort updateStationPort,
             SendKafkaMessagePort sendKafkaMessagePort,
@@ -125,7 +125,7 @@ public class ServiceConfig {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationArrivalDistanceRequestPort,
-                createStationArrivalDistanceRequestPort,
+                createIfNotExistsStationArrivalDistanceRequestPort,
                 deleteStationArrivalDistanceRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -141,7 +141,7 @@ public class ServiceConfig {
             LoadAllSystemCoordinateRequestsPort loadAllSystemCoordinateRequestsPort,
             CreateOrLoadSystemPort createOrLoadSystemPort,
             ExistsSystemCoordinateRequestPort existsSystemCoordinateRequestPort,
-            CreateSystemCoordinateRequestPort createSystemCoordinateRequestPort,
+            CreateIfNotExistsSystemCoordinateRequestPort createIfNotExistsSystemCoordinateRequestPort,
             DeleteSystemCoordinateRequestPort deleteSystemCoordinateRequestPort,
             UpdateSystemPort updateSystemPort,
             SendKafkaMessagePort sendKafkaMessagePort,
@@ -155,7 +155,7 @@ public class ServiceConfig {
                 loadAllSystemCoordinateRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemCoordinateRequestPort,
-                createSystemCoordinateRequestPort,
+                createIfNotExistsSystemCoordinateRequestPort,
                 deleteSystemCoordinateRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,
@@ -173,7 +173,7 @@ public class ServiceConfig {
             CreateOrLoadSystemPort createOrLoadSystemPort,
             CreateOrLoadStationPort createOrLoadStationPort,
             ExistsStationLandingPadSizeRequestPort existsStationLandingPadSizeRequestPort,
-            CreateStationLandingPadSizeRequestPort createStationLandingPadSizeRequestPort,
+            CreateIfNotExistsStationLandingPadSizeRequestPort createIfNotExistsStationLandingPadSizeRequestPort,
             DeleteStationLandingPadSizeRequestPort deleteStationLandingPadSizeRequestPort,
             UpdateStationPort updateStationPort,
             SendKafkaMessagePort sendKafkaMessagePort,
@@ -188,7 +188,7 @@ public class ServiceConfig {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationLandingPadSizeRequestPort,
-                createStationLandingPadSizeRequestPort,
+                createIfNotExistsStationLandingPadSizeRequestPort,
                 deleteStationLandingPadSizeRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -206,7 +206,7 @@ public class ServiceConfig {
             CreateOrLoadSystemPort createOrLoadSystemPort,
             CreateOrLoadStationPort createOrLoadStationPort,
             ExistsStationPlanetaryRequestPort existsStationPlanetaryRequestPort,
-            CreateStationPlanetaryRequestPort createStationPlanetaryRequestPort,
+            CreateIfNotExistsStationPlanetaryRequestPort createIfNotExistsStationPlanetaryRequestPort,
             DeleteStationPlanetaryRequestPort deleteStationPlanetaryRequestPort,
             UpdateStationPort updateStationPort,
             SendKafkaMessagePort sendKafkaMessagePort,
@@ -221,7 +221,7 @@ public class ServiceConfig {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationPlanetaryRequestPort,
-                createStationPlanetaryRequestPort,
+                createIfNotExistsStationPlanetaryRequestPort,
                 deleteStationPlanetaryRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -239,7 +239,7 @@ public class ServiceConfig {
             CreateOrLoadSystemPort createOrLoadSystemPort,
             CreateOrLoadStationPort createOrLoadStationPort,
             ExistsStationRequireOdysseyRequestPort existsStationRequireOdysseyRequestPort,
-            CreateStationRequireOdysseyRequestPort createStationRequireOdysseyRequestPort,
+            CreateIfNotExistsStationRequireOdysseyRequestPort createIfNotExistsStationRequireOdysseyRequestPort,
             DeleteStationRequireOdysseyRequestPort deleteStationRequireOdysseyRequestPort,
             UpdateStationPort updateStationPort,
             SendKafkaMessagePort sendKafkaMessagePort,
@@ -254,7 +254,7 @@ public class ServiceConfig {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationRequireOdysseyRequestPort,
-                createStationRequireOdysseyRequestPort,
+                createIfNotExistsStationRequireOdysseyRequestPort,
                 deleteStationRequireOdysseyRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -271,7 +271,7 @@ public class ServiceConfig {
             LoadAllSystemEliteIdRequestsPort loadAllSystemEliteIdRequestsPort,
             CreateOrLoadSystemPort createOrLoadSystemPort,
             ExistsSystemEliteIdRequestPort existsSystemEliteIdRequestPort,
-            CreateSystemEliteIdRequestPort createSystemEliteIdRequestPort,
+            CreateIfNotExistsSystemEliteIdRequestPort createIfNotExistsSystemEliteIdRequestPort,
             DeleteSystemEliteIdRequestPort deleteSystemEliteIdRequestPort,
             UpdateSystemPort updateSystemPort,
             SendKafkaMessagePort sendKafkaMessagePort,
@@ -285,7 +285,7 @@ public class ServiceConfig {
                 loadAllSystemEliteIdRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemEliteIdRequestPort,
-                createSystemEliteIdRequestPort,
+                createIfNotExistsSystemEliteIdRequestPort,
                 deleteSystemEliteIdRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationArrivalDistanceRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationArrivalDistanceRequestRepository.java
@@ -4,7 +4,7 @@ package io.edpn.backend.trade.adapter.persistence;
 import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationArrivalDistanceRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.DeleteStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.ExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.LoadAllStationArrivalDistanceRequestsPort;
@@ -15,14 +15,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
-public class StationArrivalDistanceRequestRepository implements CreateStationArrivalDistanceRequestPort, ExistsStationArrivalDistanceRequestPort, DeleteStationArrivalDistanceRequestPort, LoadAllStationArrivalDistanceRequestsPort {
+public class StationArrivalDistanceRequestRepository implements CreateIfNotExistsStationArrivalDistanceRequestPort, ExistsStationArrivalDistanceRequestPort, DeleteStationArrivalDistanceRequestPort, LoadAllStationArrivalDistanceRequestsPort {
 
     private final MybatisStationArrivalDistanceRequestRepository mybatisStationArrivalDistanceRequestRepository;
     private final MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
     @Override
-    public void create(String systemName, String stationName) {
-        mybatisStationArrivalDistanceRequestRepository.insert(systemName, stationName);
+    public void createIfNotExists(String systemName, String stationName) {
+        mybatisStationArrivalDistanceRequestRepository.insertIfNotExists(systemName, stationName);
     }
 
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationLandingPadSizeRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationLandingPadSizeRequestRepository.java
@@ -4,7 +4,7 @@ package io.edpn.backend.trade.adapter.persistence;
 import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationLandingPadSizeRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
@@ -15,14 +15,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
-public class StationLandingPadSizeRequestRepository implements CreateStationLandingPadSizeRequestPort, ExistsStationLandingPadSizeRequestPort, DeleteStationLandingPadSizeRequestPort, LoadAllStationLandingPadSizeRequestsPort {
+public class StationLandingPadSizeRequestRepository implements CreateIfNotExistsStationLandingPadSizeRequestPort, ExistsStationLandingPadSizeRequestPort, DeleteStationLandingPadSizeRequestPort, LoadAllStationLandingPadSizeRequestsPort {
 
     private final MybatisStationLandingPadSizeRequestRepository mybatisStationLandingPadSizeRequestRepository;
     private final MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
     @Override
-    public void create(String systemName, String stationName) {
-        mybatisStationLandingPadSizeRequestRepository.insert(systemName, stationName);
+    public void createIfNotExists(String systemName, String stationName) {
+        mybatisStationLandingPadSizeRequestRepository.insertIfNotExists(systemName, stationName);
     }
 
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationPlanetaryRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationPlanetaryRequestRepository.java
@@ -4,7 +4,7 @@ package io.edpn.backend.trade.adapter.persistence;
 import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationPlanetaryRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
@@ -15,14 +15,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
-public class StationPlanetaryRequestRepository implements CreateStationPlanetaryRequestPort, ExistsStationPlanetaryRequestPort, DeleteStationPlanetaryRequestPort, LoadAllStationPlanetaryRequestsPort {
+public class StationPlanetaryRequestRepository implements CreateIfNotExistsStationPlanetaryRequestPort, ExistsStationPlanetaryRequestPort, DeleteStationPlanetaryRequestPort, LoadAllStationPlanetaryRequestsPort {
 
     private final MybatisStationPlanetaryRequestRepository mybatisStationPlanetaryRequestRepository;
     private final MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
     @Override
-    public void create(String systemName, String stationName) {
-        mybatisStationPlanetaryRequestRepository.insert(systemName, stationName);
+    public void createIfNotExists(String systemName, String stationName) {
+        mybatisStationPlanetaryRequestRepository.insertIfNotExists(systemName, stationName);
     }
 
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationRequireOdysseyRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/StationRequireOdysseyRequestRepository.java
@@ -4,7 +4,7 @@ package io.edpn.backend.trade.adapter.persistence;
 import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationRequireOdysseyRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
@@ -15,14 +15,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
-public class StationRequireOdysseyRequestRepository implements CreateStationRequireOdysseyRequestPort, ExistsStationRequireOdysseyRequestPort, DeleteStationRequireOdysseyRequestPort, LoadAllStationRequireOdysseyRequestsPort {
+public class StationRequireOdysseyRequestRepository implements CreateIfNotExistsStationRequireOdysseyRequestPort, ExistsStationRequireOdysseyRequestPort, DeleteStationRequireOdysseyRequestPort, LoadAllStationRequireOdysseyRequestsPort {
 
     private final MybatisStationRequireOdysseyRequestRepository mybatisStationRequireOdysseyRequestRepository;
     private final MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
     @Override
-    public void create(String systemName, String stationName) {
-        mybatisStationRequireOdysseyRequestRepository.insert(systemName, stationName);
+    public void createIfNotExists(String systemName, String stationName) {
+        mybatisStationRequireOdysseyRequestRepository.insertIfNotExists(systemName, stationName);
     }
 
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/SystemCoordinateRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/SystemCoordinateRequestRepository.java
@@ -4,7 +4,7 @@ package io.edpn.backend.trade.adapter.persistence;
 import io.edpn.backend.trade.application.domain.intermodulecommunication.SystemDataRequest;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisSystemDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisSystemCoordinateRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
@@ -15,14 +15,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
-public class SystemCoordinateRequestRepository implements CreateSystemCoordinateRequestPort, ExistsSystemCoordinateRequestPort, DeleteSystemCoordinateRequestPort, LoadAllSystemCoordinateRequestsPort {
+public class SystemCoordinateRequestRepository implements CreateIfNotExistsSystemCoordinateRequestPort, ExistsSystemCoordinateRequestPort, DeleteSystemCoordinateRequestPort, LoadAllSystemCoordinateRequestsPort {
 
     private final MybatisSystemCoordinateRequestRepository mybatisSystemCoordinateRequestRepository;
     private final MybatisSystemDataRequestEntityMapper mybatisSystemDataRequestEntityMapper;
 
     @Override
-    public void create(String systemName) {
-        mybatisSystemCoordinateRequestRepository.insert(systemName);
+    public void createIfNotExists(String systemName) {
+        mybatisSystemCoordinateRequestRepository.insertIfNotExists(systemName);
     }
 
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/SystemEliteIdRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/SystemEliteIdRequestRepository.java
@@ -4,7 +4,7 @@ package io.edpn.backend.trade.adapter.persistence;
 import io.edpn.backend.trade.application.domain.intermodulecommunication.SystemDataRequest;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisSystemDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisSystemEliteIdRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.DeleteSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.ExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.LoadAllSystemEliteIdRequestsPort;
@@ -15,14 +15,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
-public class SystemEliteIdRequestRepository implements CreateSystemEliteIdRequestPort, ExistsSystemEliteIdRequestPort, DeleteSystemEliteIdRequestPort, LoadAllSystemEliteIdRequestsPort {
+public class SystemEliteIdRequestRepository implements CreateIfNotExistsSystemEliteIdRequestPort, ExistsSystemEliteIdRequestPort, DeleteSystemEliteIdRequestPort, LoadAllSystemEliteIdRequestsPort {
 
     private final MybatisSystemEliteIdRequestRepository mybatisSystemEliteIdRequestRepository;
     private final MybatisSystemDataRequestEntityMapper mybatisSystemDataRequestEntityMapper;
 
     @Override
-    public void create(String systemName) {
-        mybatisSystemEliteIdRequestRepository.insert(systemName);
+    public void createIfNotExists(String systemName) {
+        mybatisSystemEliteIdRequestRepository.insertIfNotExists(systemName);
     }
 
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationArrivalDistanceRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationArrivalDistanceRequestRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public interface MybatisStationArrivalDistanceRequestRepository {
 
-    @Insert("INSERT INTO station_arrival_distance_data_request (system_name, station_name) VALUES (#{systemName}, #{stationName})")
-    void insert(@Param("systemName") String systemName, @Param("stationName") String stationName);
+    @Insert("INSERT INTO station_arrival_distance_data_request (system_name, station_name)" +
+            "VALUES (#{systemName}, #{stationName})" +
+            "ON CONFLICT (system_name, station_name)" +
+            "DO NOTHING ")
+    void insertIfNotExists(@Param("systemName") String systemName, @Param("stationName") String stationName);
 
     @Delete("DELETE FROM station_arrival_distance_data_request WHERE system_name = #{systemName} AND station_Name = #{stationName}")
     void delete(@Param("systemName") String systemName, @Param("stationName") String stationName);

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationLandingPadSizeRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationLandingPadSizeRequestRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public interface MybatisStationLandingPadSizeRequestRepository {
 
-    @Insert("INSERT INTO station_landing_pad_size_data_request (system_name, station_name) VALUES (#{systemName}, #{stationName})")
-    void insert(@Param("systemName") String systemName, @Param("stationName") String stationName);
+    @Insert("INSERT INTO station_landing_pad_size_data_request (system_name, station_name)" +
+            "VALUES (#{systemName}, #{stationName})" +
+            "ON CONFLICT (system_name, station_name)" +
+            "DO NOTHING ")
+    void insertIfNotExists(@Param("systemName") String systemName, @Param("stationName") String stationName);
 
     @Delete("DELETE FROM station_landing_pad_size_data_request WHERE system_name = #{systemName} AND station_Name = #{stationName}")
     void delete(@Param("systemName") String systemName, @Param("stationName") String stationName);

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationPlanetaryRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationPlanetaryRequestRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public interface MybatisStationPlanetaryRequestRepository {
 
-    @Insert("INSERT INTO station_planetary_data_request (system_name, station_name) VALUES (#{systemName}, #{stationName})")
-    void insert(@Param("systemName") String systemName, @Param("stationName") String stationName);
+    @Insert("INSERT INTO station_planetary_data_request (system_name, station_name)" +
+            "VALUES (#{systemName}, #{stationName})" +
+            "ON CONFLICT (system_name, station_name)" +
+            "DO NOTHING ")
+    void insertIfNotExists(@Param("systemName") String systemName, @Param("stationName") String stationName);
 
     @Delete("DELETE FROM station_planetary_data_request WHERE system_name = #{systemName} AND station_Name = #{stationName}")
     void delete(@Param("systemName") String systemName, @Param("stationName") String stationName);

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationRequireOdysseyRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationRequireOdysseyRequestRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public interface MybatisStationRequireOdysseyRequestRepository {
 
-    @Insert("INSERT INTO station_require_odyssey_data_request (system_name, station_name) VALUES (#{systemName}, #{stationName})")
-    void insert(@Param("systemName") String systemName, @Param("stationName") String stationName);
+    @Insert("INSERT INTO station_require_odyssey_data_request (system_name, station_name)" +
+            "VALUES (#{systemName}, #{stationName})" +
+            "ON CONFLICT (system_name, station_name)" +
+            "DO NOTHING ")
+    void insertIfNotExists(@Param("systemName") String systemName, @Param("stationName") String stationName);
 
     @Delete("DELETE FROM station_require_odyssey_data_request WHERE system_name = #{systemName} AND station_Name = #{stationName}")
     void delete(@Param("systemName") String systemName, @Param("stationName") String stationName);

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisSystemCoordinateRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisSystemCoordinateRequestRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public interface MybatisSystemCoordinateRequestRepository {
 
-    @Insert("INSERT INTO system_coordinate_data_request (system_name) VALUES (#{systemName})")
-    void insert(@Param("systemName") String systemName);
+    @Insert("INSERT INTO system_coordinate_data_request (system_name)" +
+            "VALUES (#{systemName})" +
+            "ON CONFLICT (system_name)" +
+            "DO NOTHING ")
+    void insertIfNotExists(@Param("systemName") String systemName);
 
     @Delete("DELETE FROM system_coordinate_data_request WHERE system_name = #{systemName}")
     void delete(@Param("systemName") String systemName);

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisSystemEliteIdRequestRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisSystemEliteIdRequestRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public interface MybatisSystemEliteIdRequestRepository {
 
-    @Insert("INSERT INTO system_elite_id_data_request (system_name) VALUES (#{systemName})")
-    void insert(@Param("systemName") String systemName);
+    @Insert("INSERT INTO system_elite_id_data_request (system_name)" +
+            "VALUES (#{systemName})" +
+            "ON CONFLICT (system_name)" +
+            "DO NOTHING ")
+    void insertIfNotExists(@Param("systemName") String systemName);
 
     @Delete("DELETE FROM system_elite_id_data_request WHERE system_name = #{systemName}")
     void delete(@Param("systemName") String systemName);

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationarrivaldistancerequest/CreateIfNotExistsStationArrivalDistanceRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationarrivaldistancerequest/CreateIfNotExistsStationArrivalDistanceRequestPort.java
@@ -1,0 +1,6 @@
+package io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest;
+
+public interface CreateIfNotExistsStationArrivalDistanceRequestPort {
+
+    void createIfNotExists(String systemName, String stationName);
+}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationarrivaldistancerequest/CreateStationArrivalDistanceRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationarrivaldistancerequest/CreateStationArrivalDistanceRequestPort.java
@@ -1,6 +1,0 @@
-package io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest;
-
-public interface CreateStationArrivalDistanceRequestPort {
-
-    void create(String systemName, String stationName);
-}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationlandingpadsizerequest/CreateIfNotExistsStationLandingPadSizeRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationlandingpadsizerequest/CreateIfNotExistsStationLandingPadSizeRequestPort.java
@@ -1,0 +1,6 @@
+package io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest;
+
+public interface CreateIfNotExistsStationLandingPadSizeRequestPort {
+
+    void createIfNotExists(String systemName, String stationName);
+}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationlandingpadsizerequest/CreateStationLandingPadSizeRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationlandingpadsizerequest/CreateStationLandingPadSizeRequestPort.java
@@ -1,6 +1,0 @@
-package io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest;
-
-public interface CreateStationLandingPadSizeRequestPort {
-
-    void create(String systemName, String stationName);
-}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationplanetaryrequest/CreateIfNotExistsStationPlanetaryRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationplanetaryrequest/CreateIfNotExistsStationPlanetaryRequestPort.java
@@ -1,0 +1,6 @@
+package io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest;
+
+public interface CreateIfNotExistsStationPlanetaryRequestPort {
+
+    void createIfNotExists(String systemName, String stationName);
+}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationplanetaryrequest/CreateStationPlanetaryRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationplanetaryrequest/CreateStationPlanetaryRequestPort.java
@@ -1,6 +1,0 @@
-package io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest;
-
-public interface CreateStationPlanetaryRequestPort {
-
-    void create(String systemName, String stationName);
-}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationrequireodysseyrequest/CreateIfNotExistsStationRequireOdysseyRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationrequireodysseyrequest/CreateIfNotExistsStationRequireOdysseyRequestPort.java
@@ -1,0 +1,6 @@
+package io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest;
+
+public interface CreateIfNotExistsStationRequireOdysseyRequestPort {
+
+    void createIfNotExists(String systemName, String stationName);
+}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationrequireodysseyrequest/CreateStationRequireOdysseyRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/stationrequireodysseyrequest/CreateStationRequireOdysseyRequestPort.java
@@ -1,6 +1,0 @@
-package io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest;
-
-public interface CreateStationRequireOdysseyRequestPort {
-
-    void create(String systemName, String stationName);
-}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemcoordinaterequest/CreateIfNotExistsSystemCoordinateRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemcoordinaterequest/CreateIfNotExistsSystemCoordinateRequestPort.java
@@ -1,0 +1,6 @@
+package io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest;
+
+public interface CreateIfNotExistsSystemCoordinateRequestPort {
+
+    void createIfNotExists(String systemName);
+}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemcoordinaterequest/CreateSystemCoordinateRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemcoordinaterequest/CreateSystemCoordinateRequestPort.java
@@ -1,6 +1,0 @@
-package io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest;
-
-public interface CreateSystemCoordinateRequestPort {
-
-    void create(String systemName);
-}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemeliteidrequest/CreateIfNotExistsSystemEliteIdRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemeliteidrequest/CreateIfNotExistsSystemEliteIdRequestPort.java
@@ -1,0 +1,6 @@
+package io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest;
+
+public interface CreateIfNotExistsSystemEliteIdRequestPort {
+
+    void createIfNotExists(String systemName);
+}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemeliteidrequest/CreateSystemEliteIdRequestPort.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/port/outgoing/systemeliteidrequest/CreateSystemEliteIdRequestPort.java
@@ -1,6 +1,0 @@
-package io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest;
-
-public interface CreateSystemEliteIdRequestPort {
-
-    void create(String systemName);
-}

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationArrivalDistanceInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationArrivalDistanceInterModuleCommunicationService.java
@@ -133,15 +133,17 @@ public class StationArrivalDistanceInterModuleCommunicationService implements Re
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        StationDataRequest stationDataRequest = new StationDataRequest(
-                Module.TRADE, station.name(), station.system().name()
-        );
-        
-        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-        Message message = new Message(Topic.Request.STATION_ARRIVAL_DISTANCE.getTopicName(), jsonNode.toString());
-        
-        sendKafkaMessagePort.send(message);
-        createIfNotExistsStationArrivalDistanceRequestPort.createIfNotExists(systemName, stationName);
-        
+        boolean shouldRequest = !existsStationArrivalDistanceRequestPort.exists(systemName, stationName);
+        if (shouldRequest) {
+            StationDataRequest stationDataRequest = new StationDataRequest(
+                    Module.TRADE, station.name(), station.system().name()
+            );
+
+            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+            Message message = new Message(Topic.Request.STATION_ARRIVAL_DISTANCE.getTopicName(), jsonNode.toString());
+
+            sendKafkaMessagePort.send(message);
+            createIfNotExistsStationArrivalDistanceRequestPort.createIfNotExists(systemName, stationName);
+        }
     }
 }

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationLandingPadSizeInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationLandingPadSizeInterModuleCommunicationService.java
@@ -66,16 +66,18 @@ public class StationLandingPadSizeInterModuleCommunicationService implements Req
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        StationDataRequest stationDataRequest = new StationDataRequest(
-                Module.TRADE, stationName, systemName
-        );
-        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-        
-        Message message = new Message(Topic.Request.STATION_MAX_LANDING_PAD_SIZE.getTopicName(), jsonNode.toString());
-        
-        sendKafkaMessagePort.send(message);
-        createIfNotExistsStationLandingPadSizeRequestPort.createIfNotExists(systemName, stationName);
-        
+        boolean shouldRequest = !existsStationLandingPadSizeRequestPort.exists(systemName, stationName);
+        if (shouldRequest) {
+            StationDataRequest stationDataRequest = new StationDataRequest(
+                    Module.TRADE, stationName, systemName
+            );
+            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+
+            Message message = new Message(Topic.Request.STATION_MAX_LANDING_PAD_SIZE.getTopicName(), jsonNode.toString());
+
+            sendKafkaMessagePort.send(message);
+            createIfNotExistsStationLandingPadSizeRequestPort.createIfNotExists(systemName, stationName);
+        }
     }
     
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationLandingPadSizeInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationLandingPadSizeInterModuleCommunicationService.java
@@ -16,7 +16,7 @@ import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStati
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CleanUpObsoleteStationLandingPadSizeRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
@@ -38,48 +38,46 @@ import java.util.concurrent.Executor;
 @RequiredArgsConstructor
 @Slf4j
 public class StationLandingPadSizeInterModuleCommunicationService implements RequestDataUseCase<Station>, RequestMissingStationLandingPadSizeUseCase, ReceiveKafkaMessageUseCase<StationMaxLandingPadSizeResponse>, CleanUpObsoleteStationLandingPadSizeRequestsUseCase {
-
+    
     public static final FindStationFilter FIND_STATION_FILTER = FindStationFilter.builder()
             .hasLandingPadSize(false)
             .build();
-
+    
     private final IdGenerator idGenerator;
     private final LoadStationsByFilterPort loadStationsByFilterPort;
     private final LoadAllStationLandingPadSizeRequestsPort loadAllStationLandingPadSizeRequestsPort;
     private final CreateOrLoadSystemPort createOrLoadSystemPort;
     private final CreateOrLoadStationPort createOrLoadStationPort;
     private final ExistsStationLandingPadSizeRequestPort existsStationLandingPadSizeRequestPort;
-    private final CreateStationLandingPadSizeRequestPort createStationLandingPadSizeRequestPort;
+    private final CreateIfNotExistsStationLandingPadSizeRequestPort createIfNotExistsStationLandingPadSizeRequestPort;
     private final DeleteStationLandingPadSizeRequestPort deleteStationLandingPadSizeRequestPort;
     private final UpdateStationPort updateStationPort;
     private final SendKafkaMessagePort sendKafkaMessagePort;
     private final RetryTemplate retryTemplate;
     private final Executor executor;
     private final ObjectMapper objectMapper;
-
+    
     @Override
     public boolean isApplicable(Station station) {
         return Objects.isNull(station.maxLandingPadSize()) || LandingPadSize.UNKNOWN == station.maxLandingPadSize();
     }
-
+    
     @Override
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        boolean shouldRequest = !existsStationLandingPadSizeRequestPort.exists(systemName, stationName);
-        if (shouldRequest) {
-            StationDataRequest stationDataRequest = new StationDataRequest(
-                    Module.TRADE, stationName, systemName
-            );
-            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-
-            Message message = new Message(Topic.Request.STATION_MAX_LANDING_PAD_SIZE.getTopicName(), jsonNode.toString());
-
-            sendKafkaMessagePort.send(message);
-            createStationLandingPadSizeRequestPort.create(systemName, stationName);
-        }
+        StationDataRequest stationDataRequest = new StationDataRequest(
+                Module.TRADE, stationName, systemName
+        );
+        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+        
+        Message message = new Message(Topic.Request.STATION_MAX_LANDING_PAD_SIZE.getTopicName(), jsonNode.toString());
+        
+        sendKafkaMessagePort.send(message);
+        createIfNotExistsStationLandingPadSizeRequestPort.createIfNotExists(systemName, stationName);
+        
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 4 * * *")
     public synchronized void cleanUpObsolete() {
@@ -94,14 +92,14 @@ public class StationLandingPadSizeInterModuleCommunicationService implements Req
                 .forEach(dataRequest -> deleteStationLandingPadSizeRequestPort.delete(dataRequest.systemName(), dataRequest.stationName()));
         log.info("cleaned obsolete StationLandingPadSizeRequests");
     }
-
+    
     @Override
     public void receive(StationMaxLandingPadSizeResponse message) {
         String systemName = message.systemName();
         String stationName = message.stationName();
         LandingPadSize landingPadSize = LandingPadSize.valueOf(message.maxLandingPadSize());
-
-
+        
+        
         CompletableFuture.supplyAsync(() ->
                         createOrLoadSystemPort.createOrLoad(new System(
                                 idGenerator.generateId(),
@@ -132,7 +130,7 @@ public class StationLandingPadSizeInterModuleCommunicationService implements Req
                 })
                 .join();
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 0/12 * * *")
     public void requestMissing() {
@@ -144,7 +142,7 @@ public class StationLandingPadSizeInterModuleCommunicationService implements Req
                             boolean sendSuccessful = retryTemplate.execute(
                                     retryContext -> sendKafkaMessagePort.send(new Message(Topic.Request.STATION_MAX_LANDING_PAD_SIZE.getTopicName(), jsonNode.toString())));
                             if (sendSuccessful) {
-                                createStationLandingPadSizeRequestPort.create(station.system().name(), station.name());
+                                createIfNotExistsStationLandingPadSizeRequestPort.createIfNotExists(station.system().name(), station.name());
                             }
                         }, executor));
         log.info("requested missing StationLandingPadSize");

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationPlanetaryInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationPlanetaryInterModuleCommunicationService.java
@@ -65,16 +65,18 @@ public class StationPlanetaryInterModuleCommunicationService implements RequestD
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        StationDataRequest stationDataRequest = new StationDataRequest(
-                Module.TRADE, stationName, systemName
-        );
-        
-        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-        Message message = new Message(Topic.Request.STATION_IS_PLANETARY.getTopicName(), jsonNode.toString());
-        
-        sendKafkaMessagePort.send(message);
-        createIfNotExistsStationPlanetaryRequestPort.createIfNotExists(systemName, stationName);
-        
+        boolean shouldRequest = !existsStationPlanetaryRequestPort.exists(systemName, stationName);
+        if (shouldRequest) {
+            StationDataRequest stationDataRequest = new StationDataRequest(
+                    Module.TRADE, stationName, systemName
+            );
+
+            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+            Message message = new Message(Topic.Request.STATION_IS_PLANETARY.getTopicName(), jsonNode.toString());
+
+            sendKafkaMessagePort.send(message);
+            createIfNotExistsStationPlanetaryRequestPort.createIfNotExists(systemName, stationName);
+        }
     }
     
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationPlanetaryInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationPlanetaryInterModuleCommunicationService.java
@@ -15,7 +15,7 @@ import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStati
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CleanUpObsoleteStationPlanetaryRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
@@ -37,48 +37,46 @@ import java.util.concurrent.Executor;
 @RequiredArgsConstructor
 @Slf4j
 public class StationPlanetaryInterModuleCommunicationService implements RequestDataUseCase<Station>, RequestMissingStationPlanetaryUseCase, ReceiveKafkaMessageUseCase<StationPlanetaryResponse>, CleanUpObsoleteStationPlanetaryRequestsUseCase {
-
+    
     public static final FindStationFilter FIND_STATION_FILTER = FindStationFilter.builder()
             .hasPlanetary(false)
             .build();
-
+    
     private final IdGenerator idGenerator;
     private final LoadStationsByFilterPort loadStationsByFilterPort;
     private final LoadAllStationPlanetaryRequestsPort loadAllStationPlanetaryRequestsPort;
     private final CreateOrLoadSystemPort createOrLoadSystemPort;
     private final CreateOrLoadStationPort createOrLoadStationPort;
     private final ExistsStationPlanetaryRequestPort existsStationPlanetaryRequestPort;
-    private final CreateStationPlanetaryRequestPort createStationPlanetaryRequestPort;
+    private final CreateIfNotExistsStationPlanetaryRequestPort createIfNotExistsStationPlanetaryRequestPort;
     private final DeleteStationPlanetaryRequestPort deleteStationPlanetaryRequestPort;
     private final UpdateStationPort updateStationPort;
     private final SendKafkaMessagePort sendKafkaMessagePort;
     private final RetryTemplate retryTemplate;
     private final Executor executor;
     private final ObjectMapper objectMapper;
-
+    
     @Override
     public boolean isApplicable(Station station) {
         return Objects.isNull(station.planetary());
     }
-
+    
     @Override
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        boolean shouldRequest = !existsStationPlanetaryRequestPort.exists(systemName, stationName);
-        if (shouldRequest) {
-            StationDataRequest stationDataRequest = new StationDataRequest(
-                    Module.TRADE, stationName, systemName
-            );
-
-            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-            Message message = new Message(Topic.Request.STATION_IS_PLANETARY.getTopicName(), jsonNode.toString());
-
-            sendKafkaMessagePort.send(message);
-            createStationPlanetaryRequestPort.create(systemName, stationName);
-        }
+        StationDataRequest stationDataRequest = new StationDataRequest(
+                Module.TRADE, stationName, systemName
+        );
+        
+        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+        Message message = new Message(Topic.Request.STATION_IS_PLANETARY.getTopicName(), jsonNode.toString());
+        
+        sendKafkaMessagePort.send(message);
+        createIfNotExistsStationPlanetaryRequestPort.createIfNotExists(systemName, stationName);
+        
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 4 * * *")
     public synchronized void cleanUpObsolete() {
@@ -93,13 +91,13 @@ public class StationPlanetaryInterModuleCommunicationService implements RequestD
                 .forEach(dataRequest -> deleteStationPlanetaryRequestPort.delete(dataRequest.systemName(), dataRequest.stationName()));
         log.info("cleaned obsolete StationPlanetaryRequests");
     }
-
+    
     @Override
     public void receive(StationPlanetaryResponse message) {
         String systemName = message.systemName();
         String stationName = message.stationName();
         boolean planetary = message.planetary();
-
+        
         CompletableFuture.supplyAsync(() -> createOrLoadSystemPort.createOrLoad(
                         new System(
                                 idGenerator.generateId(),
@@ -131,7 +129,7 @@ public class StationPlanetaryInterModuleCommunicationService implements RequestD
                 })
                 .join();
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 0/12 * * *")
     public void requestMissing() {
@@ -139,14 +137,14 @@ public class StationPlanetaryInterModuleCommunicationService implements RequestD
                 .forEach(station ->
                         CompletableFuture.runAsync(() -> {
                             StationDataRequest stationDataRequest = new StationDataRequest(Module.TRADE, station.name(), station.system().name());
-
+                            
                             JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
                             Message message = new Message(Topic.Request.STATION_IS_PLANETARY.getTopicName(), jsonNode.toString());
-
+                            
                             boolean sendSuccessful = retryTemplate.execute(retryContext ->
                                     sendKafkaMessagePort.send(message));
                             if (sendSuccessful) {
-                                createStationPlanetaryRequestPort.create(station.system().name(), station.name());
+                                createIfNotExistsStationPlanetaryRequestPort.createIfNotExists(station.system().name(), station.name());
                             }
                         }, executor));
         log.info("requested missing StationPlanetary");

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationRequireOdysseyInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationRequireOdysseyInterModuleCommunicationService.java
@@ -65,15 +65,17 @@ public class StationRequireOdysseyInterModuleCommunicationService implements Req
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        StationDataRequest stationDataRequest = new StationDataRequest(
-                Module.TRADE, stationName, systemName
-        );
-        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-        Message message = new Message(Topic.Request.STATION_REQUIRE_ODYSSEY.getTopicName(), jsonNode.toString());
-        
-        sendKafkaMessagePort.send(message);
-        createIfNotExistsStationRequireOdysseyRequestPort.createIfNotExists(systemName, stationName);
-        
+        boolean shouldRequest = !existsStationRequireOdysseyRequestPort.exists(systemName, stationName);
+        if (shouldRequest) {
+            StationDataRequest stationDataRequest = new StationDataRequest(
+                    Module.TRADE, stationName, systemName
+            );
+            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+            Message message = new Message(Topic.Request.STATION_REQUIRE_ODYSSEY.getTopicName(), jsonNode.toString());
+
+            sendKafkaMessagePort.send(message);
+            createIfNotExistsStationRequireOdysseyRequestPort.createIfNotExists(systemName, stationName);
+        }
     }
     
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationRequireOdysseyInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/StationRequireOdysseyInterModuleCommunicationService.java
@@ -15,7 +15,7 @@ import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStati
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CleanUpObsoleteStationRequireOdysseyRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
@@ -37,47 +37,45 @@ import java.util.concurrent.Executor;
 @RequiredArgsConstructor
 @Slf4j
 public class StationRequireOdysseyInterModuleCommunicationService implements RequestDataUseCase<Station>, RequestMissingStationRequireOdysseyUseCase, ReceiveKafkaMessageUseCase<StationRequireOdysseyResponse>, CleanUpObsoleteStationRequireOdysseyRequestsUseCase {
-
+    
     public static final FindStationFilter FIND_STATION_FILTER = FindStationFilter.builder()
             .hasRequiredOdyssey(false)
             .build();
-
+    
     private final IdGenerator idGenerator;
     private final LoadStationsByFilterPort loadStationsByFilterPort;
     private final LoadAllStationRequireOdysseyRequestsPort loadAllStationRequireOdysseyRequestsPort;
     private final CreateOrLoadSystemPort createOrLoadSystemPort;
     private final CreateOrLoadStationPort createOrLoadStationPort;
     private final ExistsStationRequireOdysseyRequestPort existsStationRequireOdysseyRequestPort;
-    private final CreateStationRequireOdysseyRequestPort createStationRequireOdysseyRequestPort;
+    private final CreateIfNotExistsStationRequireOdysseyRequestPort createIfNotExistsStationRequireOdysseyRequestPort;
     private final DeleteStationRequireOdysseyRequestPort deleteStationRequireOdysseyRequestPort;
     private final UpdateStationPort updateStationPort;
     private final SendKafkaMessagePort sendKafkaMessagePort;
     private final RetryTemplate retryTemplate;
     private final Executor executor;
     private final ObjectMapper objectMapper;
-
+    
     @Override
     public boolean isApplicable(Station station) {
         return Objects.isNull(station.requireOdyssey());
     }
-
+    
     @Override
     public synchronized void request(Station station) {
         String stationName = station.name();
         String systemName = station.system().name();
-        boolean shouldRequest = !existsStationRequireOdysseyRequestPort.exists(systemName, stationName);
-        if (shouldRequest) {
-            StationDataRequest stationDataRequest = new StationDataRequest(
-                    Module.TRADE, stationName, systemName
-            );
-            JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
-            Message message = new Message(Topic.Request.STATION_REQUIRE_ODYSSEY.getTopicName(), jsonNode.toString());
-
-            sendKafkaMessagePort.send(message);
-            createStationRequireOdysseyRequestPort.create(systemName, stationName);
-        }
+        StationDataRequest stationDataRequest = new StationDataRequest(
+                Module.TRADE, stationName, systemName
+        );
+        JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
+        Message message = new Message(Topic.Request.STATION_REQUIRE_ODYSSEY.getTopicName(), jsonNode.toString());
+        
+        sendKafkaMessagePort.send(message);
+        createIfNotExistsStationRequireOdysseyRequestPort.createIfNotExists(systemName, stationName);
+        
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 0/12 * * *")
     public void requestMissing() {
@@ -85,19 +83,19 @@ public class StationRequireOdysseyInterModuleCommunicationService implements Req
                 .forEach(station ->
                         CompletableFuture.runAsync(() -> {
                             StationDataRequest stationDataRequest = new StationDataRequest(Module.TRADE, station.name(), station.system().name());
-
+                            
                             JsonNode jsonNode = objectMapper.valueToTree(stationDataRequest);
                             Message message = new Message(Topic.Request.STATION_REQUIRE_ODYSSEY.getTopicName(), jsonNode.toString());
-
+                            
                             boolean sendSuccessful = retryTemplate.execute(retryContext ->
                                     sendKafkaMessagePort.send(message));
                             if (sendSuccessful) {
-                                createStationRequireOdysseyRequestPort.create(station.system().name(), station.name());
+                                createIfNotExistsStationRequireOdysseyRequestPort.createIfNotExists(station.system().name(), station.name());
                             }
                         }, executor));
         log.info("requested missing StationRequireOdyssey");
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 4 * * *")
     public synchronized void cleanUpObsolete() {
@@ -112,13 +110,13 @@ public class StationRequireOdysseyInterModuleCommunicationService implements Req
                 .forEach(dataRequest -> deleteStationRequireOdysseyRequestPort.delete(dataRequest.systemName(), dataRequest.stationName()));
         log.info("cleaned obsolete StationRequireOdysseyRequests");
     }
-
+    
     @Override
     public void receive(StationRequireOdysseyResponse message) {
         String systemName = message.systemName();
         String stationName = message.stationName();
         boolean requireOdyssey = message.requireOdyssey();
-
+        
         CompletableFuture.supplyAsync(() -> createOrLoadSystemPort.createOrLoad(
                         new System(
                                 idGenerator.generateId(),

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/SystemCoordinateInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/SystemCoordinateInterModuleCommunicationService.java
@@ -15,7 +15,7 @@ import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystem
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CleanUpObsoleteSystemCoordinateRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
@@ -39,40 +39,38 @@ public class SystemCoordinateInterModuleCommunicationService implements RequestD
     public static final FindSystemFilter FIND_SYSTEM_FILTER = FindSystemFilter.builder()
             .hasCoordinates(false)
             .build();
-
+    
     private final IdGenerator idGenerator;
     private final LoadSystemsByFilterPort loadSystemsByFilterPort;
     private final LoadAllSystemCoordinateRequestsPort loadAllSystemCoordinateRequestsPort;
     private final CreateOrLoadSystemPort createOrLoadSystemPort;
     private final ExistsSystemCoordinateRequestPort existsSystemCoordinateRequestPort;
-    private final CreateSystemCoordinateRequestPort createSystemCoordinateRequestPort;
+    private final CreateIfNotExistsSystemCoordinateRequestPort createIfNotExistsSystemCoordinateRequestPort;
     private final DeleteSystemCoordinateRequestPort deleteSystemCoordinateRequestPort;
     private final UpdateSystemPort updateSystemPort;
     private final SendKafkaMessagePort sendKafkaMessagePort;
     private final RetryTemplate retryTemplate;
     private final Executor executor;
     private final ObjectMapper objectMapper;
-
+    
     @Override
     public boolean isApplicable(System system) {
         return Objects.isNull(system.coordinate().x()) || Objects.isNull(system.coordinate().y()) || Objects.isNull(system.coordinate().z());
     }
-
+    
     @Override
     public synchronized void request(System system) {
         final String systemName = system.name();
-        boolean shouldRequest = !existsSystemCoordinateRequestPort.exists(systemName);
-        if (shouldRequest) {
-            SystemDataRequest systemDataRequest = new SystemDataRequest(Module.TRADE, systemName);
-
-            JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
-            Message message = new Message(Topic.Request.SYSTEM_COORDINATES.getTopicName(), jsonNode.toString());
-
-            sendKafkaMessagePort.send(message);
-            createSystemCoordinateRequestPort.create(systemName);
-        }
+        SystemDataRequest systemDataRequest = new SystemDataRequest(Module.TRADE, systemName);
+        
+        JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
+        Message message = new Message(Topic.Request.SYSTEM_COORDINATES.getTopicName(), jsonNode.toString());
+        
+        sendKafkaMessagePort.send(message);
+        createIfNotExistsSystemCoordinateRequestPort.createIfNotExists(systemName);
+        
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 0/12 * * *")
     public void requestMissing() {
@@ -81,23 +79,23 @@ public class SystemCoordinateInterModuleCommunicationService implements RequestD
                 .hasEliteId(null)
                 .name(null)
                 .build();
-
+        
         loadSystemsByFilterPort.loadByFilter(filter).parallelStream()
                 .forEach(system ->
                         CompletableFuture.runAsync(() -> {
                             SystemDataRequest systemDataRequest = new SystemDataRequest(Module.TRADE, system.name());
-
+                            
                             JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
                             Message message = new Message(Topic.Request.SYSTEM_COORDINATES.getTopicName(), jsonNode.toString());
-
+                            
                             boolean sendSuccessful = retryTemplate.execute(retryContext -> sendKafkaMessagePort.send(message));
                             if (sendSuccessful) {
-                                createSystemCoordinateRequestPort.create(system.name());
+                                createIfNotExistsSystemCoordinateRequestPort.createIfNotExists(system.name());
                             }
                         }, executor));
         log.info("requested missing SystemCoordinate");
     }
-
+    
     @Override
     @Scheduled(cron = "0 0 4 * * *")
     public synchronized void cleanUpObsolete() {
@@ -112,14 +110,14 @@ public class SystemCoordinateInterModuleCommunicationService implements RequestD
                 .forEach(dataRequest -> deleteSystemCoordinateRequestPort.delete(dataRequest.systemName()));
         log.info("cleaned obsolete SystemCoordinateRequests");
     }
-
+    
     @Override
     public void receive(SystemCoordinatesResponse message) {
         final String systemName = message.systemName();
         final double xCoordinate = message.xCoordinate();
         final double yCoordinate = message.yCoordinate();
         final double zCoordinate = message.zCoordinate();
-
+        
         CompletableFuture.supplyAsync(() ->
                         createOrLoadSystemPort.createOrLoad(
                                 new System(

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/SystemCoordinateInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/SystemCoordinateInterModuleCommunicationService.java
@@ -61,14 +61,16 @@ public class SystemCoordinateInterModuleCommunicationService implements RequestD
     @Override
     public synchronized void request(System system) {
         final String systemName = system.name();
-        SystemDataRequest systemDataRequest = new SystemDataRequest(Module.TRADE, systemName);
-        
-        JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
-        Message message = new Message(Topic.Request.SYSTEM_COORDINATES.getTopicName(), jsonNode.toString());
-        
-        sendKafkaMessagePort.send(message);
-        createIfNotExistsSystemCoordinateRequestPort.createIfNotExists(systemName);
-        
+        boolean shouldRequest = !existsSystemCoordinateRequestPort.exists(systemName);
+        if (shouldRequest) {
+            SystemDataRequest systemDataRequest = new SystemDataRequest(Module.TRADE, systemName);
+
+            JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
+            Message message = new Message(Topic.Request.SYSTEM_COORDINATES.getTopicName(), jsonNode.toString());
+
+            sendKafkaMessagePort.send(message);
+            createIfNotExistsSystemCoordinateRequestPort.createIfNotExists(systemName);
+        }
     }
     
     @Override

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/service/SystemEliteIdInterModuleCommunicationService.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/service/SystemEliteIdInterModuleCommunicationService.java
@@ -60,14 +60,17 @@ public class SystemEliteIdInterModuleCommunicationService implements RequestData
     @Override
     public synchronized void request(System system) {
         String systemName = system.name();
-        SystemDataRequest systemDataRequest = new SystemDataRequest(
-                Module.TRADE, systemName
-        );
-        JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
-        Message message = new Message(Topic.Request.SYSTEM_ELITE_ID.getTopicName(), jsonNode.toString());
-        
-        sendKafkaMessagePort.send(message);
-        createIfNotExistsSystemEliteIdRequestPort.createIfNotExists(systemName);
+        boolean shouldRequest = !existsSystemEliteIdRequestPort.exists(systemName);
+        if (shouldRequest) {
+            SystemDataRequest systemDataRequest = new SystemDataRequest(
+                    Module.TRADE, systemName
+            );
+            JsonNode jsonNode = objectMapper.valueToTree(systemDataRequest);
+            Message message = new Message(Topic.Request.SYSTEM_ELITE_ID.getTopicName(), jsonNode.toString());
+
+            sendKafkaMessagePort.send(message);
+            createIfNotExistsSystemEliteIdRequestPort.createIfNotExists(systemName);
+        }
     }
     
     @Override

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationarrivaldistancerequest/CreateStationArrivalDistanceRequestPortTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationarrivaldistancerequest/CreateStationArrivalDistanceRequestPortTest.java
@@ -3,7 +3,7 @@ package io.edpn.backend.trade.adapter.persistence.stationarrivaldistancerequest;
 import io.edpn.backend.trade.adapter.persistence.StationArrivalDistanceRequestRepository;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationArrivalDistanceRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +20,7 @@ public class CreateStationArrivalDistanceRequestPortTest {
     @Mock
     private MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
-    private CreateStationArrivalDistanceRequestPort underTest;
+    private CreateIfNotExistsStationArrivalDistanceRequestPort underTest;
 
     @BeforeEach
     public void setup() {
@@ -32,9 +32,9 @@ public class CreateStationArrivalDistanceRequestPortTest {
         String systemName = "someName";
         String stationName = "someName2";
 
-        underTest.create(systemName, stationName);
+        underTest.createIfNotExists(systemName, stationName);
 
-        verify(mybatisStationArrivalDistanceRequestRepository).insert(systemName, stationName);
+        verify(mybatisStationArrivalDistanceRequestRepository).insertIfNotExists(systemName, stationName);
     }
 
 

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationlandingpadsizerequest/CreateIfNotExistsStationLandingPadSizeRequestPortTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationlandingpadsizerequest/CreateIfNotExistsStationLandingPadSizeRequestPortTest.java
@@ -3,7 +3,7 @@ package io.edpn.backend.trade.adapter.persistence.stationlandingpadsizerequest;
 import io.edpn.backend.trade.adapter.persistence.StationLandingPadSizeRequestRepository;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationLandingPadSizeRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CreateStationLandingPadSizeRequestPortTest {
+public class CreateIfNotExistsStationLandingPadSizeRequestPortTest {
 
     @Mock
     private MybatisStationLandingPadSizeRequestRepository mybatisStationLandingPadSizeRequestRepository;
     @Mock
     private MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
-    private CreateStationLandingPadSizeRequestPort underTest;
+    private CreateIfNotExistsStationLandingPadSizeRequestPort underTest;
 
     @BeforeEach
     public void setup() {
@@ -32,9 +32,9 @@ public class CreateStationLandingPadSizeRequestPortTest {
         String systemName = "someName";
         String stationName = "someName2";
 
-        underTest.create(systemName, stationName);
+        underTest.createIfNotExists(systemName, stationName);
 
-        verify(mybatisStationLandingPadSizeRequestRepository).insert(systemName, stationName);
+        verify(mybatisStationLandingPadSizeRequestRepository).insertIfNotExists(systemName, stationName);
     }
 
 

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationplanetaryrequest/CreateIfNotExistsStationPlanetaryRequestPortTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationplanetaryrequest/CreateIfNotExistsStationPlanetaryRequestPortTest.java
@@ -3,7 +3,7 @@ package io.edpn.backend.trade.adapter.persistence.stationplanetaryrequest;
 import io.edpn.backend.trade.adapter.persistence.StationPlanetaryRequestRepository;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationPlanetaryRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CreateStationPlanetaryRequestPortTest {
+public class CreateIfNotExistsStationPlanetaryRequestPortTest {
 
     @Mock
     private MybatisStationPlanetaryRequestRepository mybatisStationPlanetaryRequestRepository;
     @Mock
     private MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
-    private CreateStationPlanetaryRequestPort underTest;
+    private CreateIfNotExistsStationPlanetaryRequestPort underTest;
 
     @BeforeEach
     public void setup() {
@@ -32,9 +32,9 @@ public class CreateStationPlanetaryRequestPortTest {
         String systemName = "someName";
         String stationName = "someName2";
 
-        underTest.create(systemName, stationName);
+        underTest.createIfNotExists(systemName, stationName);
 
-        verify(mybatisStationPlanetaryRequestRepository).insert(systemName, stationName);
+        verify(mybatisStationPlanetaryRequestRepository).insertIfNotExists(systemName, stationName);
     }
 
 

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationrequireodysseyrequest/CreateIfNotExistsStationRequireOdysseyRequestPortTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/stationrequireodysseyrequest/CreateIfNotExistsStationRequireOdysseyRequestPortTest.java
@@ -3,7 +3,7 @@ package io.edpn.backend.trade.adapter.persistence.stationrequireodysseyrequest;
 import io.edpn.backend.trade.adapter.persistence.StationRequireOdysseyRequestRepository;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisStationDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisStationRequireOdysseyRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CreateStationRequireOdysseyRequestPortTest {
+public class CreateIfNotExistsStationRequireOdysseyRequestPortTest {
 
     @Mock
     private MybatisStationRequireOdysseyRequestRepository mybatisStationRequireOdysseyRequestRepository;
     @Mock
     private MybatisStationDataRequestEntityMapper mybatisStationDataRequestEntityMapper;
 
-    private CreateStationRequireOdysseyRequestPort underTest;
+    private CreateIfNotExistsStationRequireOdysseyRequestPort underTest;
 
     @BeforeEach
     public void setup() {
@@ -32,9 +32,9 @@ public class CreateStationRequireOdysseyRequestPortTest {
         String systemName = "someName";
         String stationName = "someName2";
 
-        underTest.create(systemName, stationName);
+        underTest.createIfNotExists(systemName, stationName);
 
-        verify(mybatisStationRequireOdysseyRequestRepository).insert(systemName, stationName);
+        verify(mybatisStationRequireOdysseyRequestRepository).insertIfNotExists(systemName, stationName);
     }
 
 

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/systemcoordinaterequest/CreateIfNotExistsSystemCoordinateRequestPortTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/systemcoordinaterequest/CreateIfNotExistsSystemCoordinateRequestPortTest.java
@@ -3,7 +3,7 @@ package io.edpn.backend.trade.adapter.persistence.systemcoordinaterequest;
 import io.edpn.backend.trade.adapter.persistence.SystemCoordinateRequestRepository;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisSystemDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisSystemCoordinateRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CreateSystemCoordinateRequestPortTest {
+public class CreateIfNotExistsSystemCoordinateRequestPortTest {
 
     @Mock
     private MybatisSystemCoordinateRequestRepository mybatisSystemCoordinateRequestRepository;
     @Mock
     private MybatisSystemDataRequestEntityMapper mybatisSystemDataRequestEntityMapper;
 
-    private CreateSystemCoordinateRequestPort underTest;
+    private CreateIfNotExistsSystemCoordinateRequestPort underTest;
 
     @BeforeEach
     public void setup() {
@@ -31,9 +31,9 @@ public class CreateSystemCoordinateRequestPortTest {
     public void testCreate() {
         String systemName = "someName";
 
-        underTest.create(systemName);
+        underTest.createIfNotExists(systemName);
 
-        verify(mybatisSystemCoordinateRequestRepository).insert(systemName);
+        verify(mybatisSystemCoordinateRequestRepository).insertIfNotExists(systemName);
     }
 
 

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/systemeliteidrequest/CreateIfNotExistsSystemEliteIdRequestPortTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/systemeliteidrequest/CreateIfNotExistsSystemEliteIdRequestPortTest.java
@@ -3,7 +3,7 @@ package io.edpn.backend.trade.adapter.persistence.systemeliteidrequest;
 import io.edpn.backend.trade.adapter.persistence.SystemEliteIdRequestRepository;
 import io.edpn.backend.trade.adapter.persistence.entity.mapper.MybatisSystemDataRequestEntityMapper;
 import io.edpn.backend.trade.adapter.persistence.repository.MybatisSystemEliteIdRequestRepository;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CreateSystemEliteIdRequestPortTest {
+public class CreateIfNotExistsSystemEliteIdRequestPortTest {
 
     @Mock
     private MybatisSystemEliteIdRequestRepository mybatisSystemEliteIdRequestRepository;
     @Mock
     private MybatisSystemDataRequestEntityMapper mybatisSystemDataRequestEntityMapper;
 
-    private CreateSystemEliteIdRequestPort underTest;
+    private CreateIfNotExistsSystemEliteIdRequestPort underTest;
 
     @BeforeEach
     public void setup() {
@@ -31,9 +31,9 @@ public class CreateSystemEliteIdRequestPortTest {
     public void testCreate() {
         String systemName = "someName";
 
-        underTest.create(systemName);
+        underTest.createIfNotExists(systemName);
 
-        verify(mybatisSystemEliteIdRequestRepository).insert(systemName);
+        verify(mybatisSystemEliteIdRequestRepository).insertIfNotExists(systemName);
     }
 
 

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationArrivalDistanceRequestsUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationArrivalDistanceRequestsUseCaseTest.java
@@ -1,24 +1,19 @@
 package io.edpn.backend.trade.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.application.domain.Station;
 import io.edpn.backend.trade.application.domain.System;
 import io.edpn.backend.trade.application.domain.filter.FindStationFilter;
+import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePort;
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CleanUpObsoleteStationArrivalDistanceRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.DeleteStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.ExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.LoadAllStationArrivalDistanceRequestsPort;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Executor;
-
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.util.IdGenerator;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +22,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.retry.support.RetryTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -54,7 +53,7 @@ public class CleanUpObsoleteStationArrivalDistanceRequestsUseCaseTest {
     @Mock
     private ExistsStationArrivalDistanceRequestPort existsStationArrivalDistanceRequestPort;
     @Mock
-    private CreateStationArrivalDistanceRequestPort createStationArrivalDistanceRequestPort;
+    private CreateIfNotExistsStationArrivalDistanceRequestPort createIfNotExistsStationArrivalDistanceRequestPort;
     @Mock
     private UpdateStationPort updateStationPort;
     @Mock
@@ -77,7 +76,7 @@ public class CleanUpObsoleteStationArrivalDistanceRequestsUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationArrivalDistanceRequestPort,
-                createStationArrivalDistanceRequestPort,
+                createIfNotExistsStationArrivalDistanceRequestPort,
                 deleteStationArrivalDistanceRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationLandingPadSizeRequestsUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationLandingPadSizeRequestsUseCaseTest.java
@@ -10,7 +10,7 @@ import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStati
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CleanUpObsoleteStationLandingPadSizeRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
@@ -51,7 +51,7 @@ public class CleanUpObsoleteStationLandingPadSizeRequestsUseCaseTest {
     @Mock
     private ExistsStationLandingPadSizeRequestPort existsStationLandingPadSizeRequestPort;
     @Mock
-    private CreateStationLandingPadSizeRequestPort createStationLandingPadSizeRequestPort;
+    private CreateIfNotExistsStationLandingPadSizeRequestPort createIfNotExistsStationLandingPadSizeRequestPort;
     @Mock
     private DeleteStationLandingPadSizeRequestPort deleteStationLandingPadSizeRequestPort;
     @Mock
@@ -76,7 +76,7 @@ public class CleanUpObsoleteStationLandingPadSizeRequestsUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationLandingPadSizeRequestPort,
-                createStationLandingPadSizeRequestPort,
+                createIfNotExistsStationLandingPadSizeRequestPort,
                 deleteStationLandingPadSizeRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationPlanetaryRequestsUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationPlanetaryRequestsUseCaseTest.java
@@ -10,7 +10,7 @@ import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStati
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CleanUpObsoleteStationPlanetaryRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
@@ -51,7 +51,7 @@ public class CleanUpObsoleteStationPlanetaryRequestsUseCaseTest {
     @Mock
     private ExistsStationPlanetaryRequestPort existsStationPlanetaryRequestPort;
     @Mock
-    private CreateStationPlanetaryRequestPort createStationPlanetaryRequestPort;
+    private CreateIfNotExistsStationPlanetaryRequestPort createIfNotExistsStationPlanetaryRequestPort;
     @Mock
     private DeleteStationPlanetaryRequestPort deleteStationPlanetaryRequestPort;
     @Mock
@@ -76,7 +76,7 @@ public class CleanUpObsoleteStationPlanetaryRequestsUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationPlanetaryRequestPort,
-                createStationPlanetaryRequestPort,
+                createIfNotExistsStationPlanetaryRequestPort,
                 deleteStationPlanetaryRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationRequireOdysseyRequestsUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteStationRequireOdysseyRequestsUseCaseTest.java
@@ -10,7 +10,7 @@ import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStati
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CleanUpObsoleteStationRequireOdysseyRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
@@ -51,7 +51,7 @@ public class CleanUpObsoleteStationRequireOdysseyRequestsUseCaseTest {
     @Mock
     private ExistsStationRequireOdysseyRequestPort existsStationRequireOdysseyRequestPort;
     @Mock
-    private CreateStationRequireOdysseyRequestPort createStationRequireOdysseyRequestPort;
+    private CreateIfNotExistsStationRequireOdysseyRequestPort createIfNotExistsStationRequireOdysseyRequestPort;
     @Mock
     private DeleteStationRequireOdysseyRequestPort deleteStationRequireOdysseyRequestPort;
     @Mock
@@ -76,7 +76,7 @@ public class CleanUpObsoleteStationRequireOdysseyRequestsUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationRequireOdysseyRequestPort,
-                createStationRequireOdysseyRequestPort,
+                createIfNotExistsStationRequireOdysseyRequestPort,
                 deleteStationRequireOdysseyRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteSystemCoordinateRequestsUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteSystemCoordinateRequestsUseCaseTest.java
@@ -9,7 +9,7 @@ import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystem
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CleanUpObsoleteSystemCoordinateRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
@@ -47,7 +47,7 @@ public class CleanUpObsoleteSystemCoordinateRequestsUseCaseTest {
     @Mock
     private ExistsSystemCoordinateRequestPort existsSystemCoordinateRequestPort;
     @Mock
-    private CreateSystemCoordinateRequestPort createSystemCoordinateRequestPort;
+    private CreateIfNotExistsSystemCoordinateRequestPort createIfNotExistsSystemCoordinateRequestPort;
     @Mock
     private DeleteSystemCoordinateRequestPort deleteSystemCoordinateRequestPort;
     @Mock
@@ -71,7 +71,7 @@ public class CleanUpObsoleteSystemCoordinateRequestsUseCaseTest {
                 loadAllSystemCoordinateRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemCoordinateRequestPort,
-                createSystemCoordinateRequestPort,
+                createIfNotExistsSystemCoordinateRequestPort,
                 deleteSystemCoordinateRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteSystemEliteIdRequestsUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/CleanUpObsoleteSystemEliteIdRequestsUseCaseTest.java
@@ -9,7 +9,7 @@ import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystem
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CleanUpObsoleteSystemEliteIdRequestsUseCase;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.DeleteSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.ExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.LoadAllSystemEliteIdRequestsPort;
@@ -47,7 +47,7 @@ public class CleanUpObsoleteSystemEliteIdRequestsUseCaseTest {
     @Mock
     private ExistsSystemEliteIdRequestPort existsSystemEliteIdRequestPort;
     @Mock
-    private CreateSystemEliteIdRequestPort createSystemEliteIdRequestPort;
+    private CreateIfNotExistsSystemEliteIdRequestPort createIfNotExistsSystemEliteIdRequestPort;
     @Mock
     private DeleteSystemEliteIdRequestPort deleteSystemEliteIdRequestPort;
     @Mock
@@ -71,7 +71,7 @@ public class CleanUpObsoleteSystemEliteIdRequestsUseCaseTest {
                 loadAllSystemEliteIdRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemEliteIdRequestPort,
-                createSystemEliteIdRequestPort,
+                createIfNotExistsSystemEliteIdRequestPort,
                 deleteSystemEliteIdRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationArrivalDistanceResponseUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationArrivalDistanceResponseUseCaseTest.java
@@ -9,19 +9,20 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.DeleteStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.ExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.LoadAllStationArrivalDistanceRequestsPort;
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.util.IdGenerator;
-import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.retry.support.RetryTemplate;
+
+import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -47,7 +48,7 @@ public class ReceiveStationArrivalDistanceResponseUseCaseTest {
     @Mock
     private ExistsStationArrivalDistanceRequestPort existsStationArrivalDistanceRequestPort;
     @Mock
-    private CreateStationArrivalDistanceRequestPort createStationArrivalDistanceRequestPort;
+    private CreateIfNotExistsStationArrivalDistanceRequestPort createIfNotExistsStationArrivalDistanceRequestPort;
     @Mock
     private UpdateStationPort updateStationPort;
     @Mock
@@ -70,7 +71,7 @@ public class ReceiveStationArrivalDistanceResponseUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationArrivalDistanceRequestPort,
-                createStationArrivalDistanceRequestPort,
+                createIfNotExistsStationArrivalDistanceRequestPort,
                 deleteStationArrivalDistanceRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationMaxLandingPadSizeResponseUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationMaxLandingPadSizeResponseUseCaseTest.java
@@ -10,7 +10,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
@@ -46,7 +46,7 @@ public class ReceiveStationMaxLandingPadSizeResponseUseCaseTest {
     @Mock
     private ExistsStationLandingPadSizeRequestPort existsStationLandingPadSizeRequestPort;
     @Mock
-    private CreateStationLandingPadSizeRequestPort createStationLandingPadSizeRequestPort;
+    private CreateIfNotExistsStationLandingPadSizeRequestPort createIfNotExistsStationLandingPadSizeRequestPort;
     @Mock
     private DeleteStationLandingPadSizeRequestPort deleteStationLandingPadSizeRequestPort;
     @Mock
@@ -71,7 +71,7 @@ public class ReceiveStationMaxLandingPadSizeResponseUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationLandingPadSizeRequestPort,
-                createStationLandingPadSizeRequestPort,
+                createIfNotExistsStationLandingPadSizeRequestPort,
                 deleteStationLandingPadSizeRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationPlanetaryResponseUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationPlanetaryResponseUseCaseTest.java
@@ -9,7 +9,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
@@ -46,7 +46,7 @@ public class ReceiveStationPlanetaryResponseUseCaseTest {
     @Mock
     private ExistsStationPlanetaryRequestPort existsStationPlanetaryRequestPort;
     @Mock
-    private CreateStationPlanetaryRequestPort createStationPlanetaryRequestPort;
+    private CreateIfNotExistsStationPlanetaryRequestPort createIfNotExistsStationPlanetaryRequestPort;
     @Mock
     private DeleteStationPlanetaryRequestPort deleteStationPlanetaryRequestPort;
     @Mock
@@ -71,7 +71,7 @@ public class ReceiveStationPlanetaryResponseUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationPlanetaryRequestPort,
-                createStationPlanetaryRequestPort,
+                createIfNotExistsStationPlanetaryRequestPort,
                 deleteStationPlanetaryRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationRequireOdysseyResponseUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveStationRequireOdysseyResponseUseCaseTest.java
@@ -9,7 +9,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
@@ -46,7 +46,7 @@ public class ReceiveStationRequireOdysseyResponseUseCaseTest {
     @Mock
     private ExistsStationRequireOdysseyRequestPort existsStationRequireOdysseyRequestPort;
     @Mock
-    private CreateStationRequireOdysseyRequestPort createStationRequireOdysseyRequestPort;
+    private CreateIfNotExistsStationRequireOdysseyRequestPort createIfNotExistsStationRequireOdysseyRequestPort;
     @Mock
     private DeleteStationRequireOdysseyRequestPort deleteStationRequireOdysseyRequestPort;
     @Mock
@@ -71,7 +71,7 @@ public class ReceiveStationRequireOdysseyResponseUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationRequireOdysseyRequestPort,
-                createStationRequireOdysseyRequestPort,
+                createIfNotExistsStationRequireOdysseyRequestPort,
                 deleteStationRequireOdysseyRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveSystemCoordinatesResponseUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveSystemCoordinatesResponseUseCaseTest.java
@@ -9,18 +9,19 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
 import io.edpn.backend.util.IdGenerator;
-import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.retry.support.RetryTemplate;
+
+import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -42,7 +43,7 @@ public class ReceiveSystemCoordinatesResponseUseCaseTest {
     @Mock
     private ExistsSystemCoordinateRequestPort existsSystemCoordinateRequestPort;
     @Mock
-    private CreateSystemCoordinateRequestPort createSystemCoordinateRequestPort;
+    private CreateIfNotExistsSystemCoordinateRequestPort createIfNotExistsSystemCoordinateRequestPort;
     @Mock
     private DeleteSystemCoordinateRequestPort deleteSystemCoordinateRequestPort;
     @Mock
@@ -66,7 +67,7 @@ public class ReceiveSystemCoordinatesResponseUseCaseTest {
                 loadAllSystemCoordinateRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemCoordinateRequestPort,
-                createSystemCoordinateRequestPort,
+                createIfNotExistsSystemCoordinateRequestPort,
                 deleteSystemCoordinateRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveSystemEliteIdResponseUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/ReceiveSystemEliteIdResponseUseCaseTest.java
@@ -8,7 +8,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.DeleteSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.ExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.LoadAllSystemEliteIdRequestsPort;
@@ -42,7 +42,7 @@ public class ReceiveSystemEliteIdResponseUseCaseTest {
     @Mock
     private ExistsSystemEliteIdRequestPort existsSystemEliteIdRequestPort;
     @Mock
-    private CreateSystemEliteIdRequestPort createSystemEliteIdRequestPort;
+    private CreateIfNotExistsSystemEliteIdRequestPort createIfNotExistsSystemEliteIdRequestPort;
     @Mock
     private DeleteSystemEliteIdRequestPort deleteSystemEliteIdRequestPort;
     @Mock
@@ -66,7 +66,7 @@ public class ReceiveSystemEliteIdResponseUseCaseTest {
                 loadAllSystemEliteIdRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemEliteIdRequestPort,
-                createSystemEliteIdRequestPort,
+                createIfNotExistsSystemEliteIdRequestPort,
                 deleteSystemEliteIdRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationArrivalDistanceUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationArrivalDistanceUseCaseTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.DeleteStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.ExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.LoadAllStationArrivalDistanceRequestsPort;
@@ -62,7 +62,7 @@ public class RequestMissingStationArrivalDistanceUseCaseTest {
     @Mock
     private ExistsStationArrivalDistanceRequestPort existsStationArrivalDistanceRequestPort;
     @Mock
-    private CreateStationArrivalDistanceRequestPort createStationArrivalDistanceRequestPort;
+    private CreateIfNotExistsStationArrivalDistanceRequestPort createIfNotExistsStationArrivalDistanceRequestPort;
     @Mock
     private UpdateStationPort updateStationPort;
     @Mock
@@ -82,7 +82,7 @@ public class RequestMissingStationArrivalDistanceUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationArrivalDistanceRequestPort,
-                createStationArrivalDistanceRequestPort,
+                createIfNotExistsStationArrivalDistanceRequestPort,
                 deleteStationArrivalDistanceRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -107,7 +107,7 @@ public class RequestMissingStationArrivalDistanceUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationArrivalDistanceRequestPort, never()).create(any(), any());
+        verify(createIfNotExistsStationArrivalDistanceRequestPort, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class RequestMissingStationArrivalDistanceUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort).send(any());
-        verify(createStationArrivalDistanceRequestPort).create(any(), any());
+        verify(createIfNotExistsStationArrivalDistanceRequestPort).createIfNotExists(any(), any());
     }
 
     @Test
@@ -178,7 +178,7 @@ public class RequestMissingStationArrivalDistanceUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, times(2)).send(any());
-        verify(createStationArrivalDistanceRequestPort, times(2)).create(any(), any());
+        verify(createIfNotExistsStationArrivalDistanceRequestPort, times(2)).createIfNotExists(any(), any());
     }
 
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationLandingPadSizeUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationLandingPadSizeUseCaseTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
@@ -59,7 +59,7 @@ public class RequestMissingStationLandingPadSizeUseCaseTest {
     @Mock
     private ExistsStationLandingPadSizeRequestPort existsStationLandingPadSizeRequestPort;
     @Mock
-    private CreateStationLandingPadSizeRequestPort createStationLandingPadSizeRequestPort;
+    private CreateIfNotExistsStationLandingPadSizeRequestPort createIfNotExistsStationLandingPadSizeRequestPort;
     @Mock
     private DeleteStationLandingPadSizeRequestPort deleteStationLandingPadSizeRequestPort;
     @Mock
@@ -81,7 +81,7 @@ public class RequestMissingStationLandingPadSizeUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationLandingPadSizeRequestPort,
-                createStationLandingPadSizeRequestPort,
+                createIfNotExistsStationLandingPadSizeRequestPort,
                 deleteStationLandingPadSizeRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -107,7 +107,7 @@ public class RequestMissingStationLandingPadSizeUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationLandingPadSizeRequestPort, never()).create(any(), any());
+        verify(createIfNotExistsStationLandingPadSizeRequestPort, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class RequestMissingStationLandingPadSizeUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort).send(any());
-        verify(createStationLandingPadSizeRequestPort).create(any(), any());
+        verify(createIfNotExistsStationLandingPadSizeRequestPort).createIfNotExists(any(), any());
     }
 
     @Test
@@ -177,7 +177,7 @@ public class RequestMissingStationLandingPadSizeUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, times(2)).send(any());
-        verify(createStationLandingPadSizeRequestPort, times(2)).create(any(), any());
+        verify(createIfNotExistsStationLandingPadSizeRequestPort, times(2)).createIfNotExists(any(), any());
     }
 
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationPlanetaryUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationPlanetaryUseCaseTest.java
@@ -2,16 +2,16 @@ package io.edpn.backend.trade.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.application.domain.Message;
 import io.edpn.backend.trade.application.domain.Station;
 import io.edpn.backend.trade.application.domain.System;
 import io.edpn.backend.trade.application.domain.filter.FindStationFilter;
+import io.edpn.backend.trade.application.domain.intermodulecommunication.StationDataRequest;
 import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePort;
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
@@ -19,10 +19,6 @@ import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.R
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.util.IdGenerator;
 import io.edpn.backend.util.Module;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Executor;
-
 import io.edpn.backend.util.Topic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +27,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.support.RetryTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -60,7 +60,7 @@ public class RequestMissingStationPlanetaryUseCaseTest {
     @Mock
     private ExistsStationPlanetaryRequestPort existsStationPlanetaryRequestPort;
     @Mock
-    private CreateStationPlanetaryRequestPort createStationPlanetaryRequestPort;
+    private CreateIfNotExistsStationPlanetaryRequestPort createIfNotExistsStationPlanetaryRequestPort;
     @Mock
     private DeleteStationPlanetaryRequestPort deleteStationPlanetaryRequestPort;
     @Mock
@@ -82,7 +82,7 @@ public class RequestMissingStationPlanetaryUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationPlanetaryRequestPort,
-                createStationPlanetaryRequestPort,
+                createIfNotExistsStationPlanetaryRequestPort,
                 deleteStationPlanetaryRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -108,7 +108,7 @@ public class RequestMissingStationPlanetaryUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationPlanetaryRequestPort, never()).create(any(), any());
+        verify(createIfNotExistsStationPlanetaryRequestPort, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class RequestMissingStationPlanetaryUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort).send(any());
-        verify(createStationPlanetaryRequestPort).create(any(), any());
+        verify(createIfNotExistsStationPlanetaryRequestPort).createIfNotExists(any(), any());
     }
 
     @Test
@@ -178,7 +178,7 @@ public class RequestMissingStationPlanetaryUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, times(2)).send(any());
-        verify(createStationPlanetaryRequestPort, times(2)).create(any(), any());
+        verify(createIfNotExistsStationPlanetaryRequestPort, times(2)).createIfNotExists(any(), any());
     }
 
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationRequireOdysseyUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingStationRequireOdysseyUseCaseTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
@@ -60,7 +60,7 @@ public class RequestMissingStationRequireOdysseyUseCaseTest {
     @Mock
     private ExistsStationRequireOdysseyRequestPort existsStationRequireOdysseyRequestPort;
     @Mock
-    private CreateStationRequireOdysseyRequestPort createStationRequireOdysseyRequestPort;
+    private CreateIfNotExistsStationRequireOdysseyRequestPort createIfNotExistsStationRequireOdysseyRequestPort;
     @Mock
     private DeleteStationRequireOdysseyRequestPort deleteStationRequireOdysseyRequestPort;
     @Mock
@@ -82,7 +82,7 @@ public class RequestMissingStationRequireOdysseyUseCaseTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationRequireOdysseyRequestPort,
-                createStationRequireOdysseyRequestPort,
+                createIfNotExistsStationRequireOdysseyRequestPort,
                 deleteStationRequireOdysseyRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -108,7 +108,7 @@ public class RequestMissingStationRequireOdysseyUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationRequireOdysseyRequestPort, never()).create(any(), any());
+        verify(createIfNotExistsStationRequireOdysseyRequestPort, never()).createIfNotExists(any(), any());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class RequestMissingStationRequireOdysseyUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort).send(any());
-        verify(createStationRequireOdysseyRequestPort).create(any(), any());
+        verify(createIfNotExistsStationRequireOdysseyRequestPort).createIfNotExists(any(), any());
     }
 
     @Test
@@ -178,7 +178,7 @@ public class RequestMissingStationRequireOdysseyUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, times(2)).send(any());
-        verify(createStationRequireOdysseyRequestPort, times(2)).create(any(), any());
+        verify(createIfNotExistsStationRequireOdysseyRequestPort, times(2)).createIfNotExists(any(), any());
     }
 
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingSystemCoordinatesUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingSystemCoordinatesUseCaseTest.java
@@ -2,25 +2,21 @@ package io.edpn.backend.trade.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.edpn.backend.trade.application.domain.intermodulecommunication.SystemDataRequest;
 import io.edpn.backend.trade.application.domain.Message;
 import io.edpn.backend.trade.application.domain.System;
 import io.edpn.backend.trade.application.domain.filter.FindSystemFilter;
+import io.edpn.backend.trade.application.domain.intermodulecommunication.SystemDataRequest;
 import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePort;
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.RequestMissingSystemCoordinatesUseCase;
 import io.edpn.backend.util.IdGenerator;
 import io.edpn.backend.util.Module;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Executor;
-
 import io.edpn.backend.util.Topic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +25,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.support.RetryTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -56,7 +56,7 @@ public class RequestMissingSystemCoordinatesUseCaseTest {
     @Mock
     private ExistsSystemCoordinateRequestPort existsSystemCoordinateRequestPort;
     @Mock
-    private CreateSystemCoordinateRequestPort createSystemCoordinateRequestPort;
+    private CreateIfNotExistsSystemCoordinateRequestPort createIfNotExistsSystemCoordinateRequestPort;
     @Mock
     private DeleteSystemCoordinateRequestPort deleteSystemCoordinateRequestPort;
     @Mock
@@ -77,7 +77,7 @@ public class RequestMissingSystemCoordinatesUseCaseTest {
                 loadAllSystemCoordinateRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemCoordinateRequestPort,
-                createSystemCoordinateRequestPort,
+                createIfNotExistsSystemCoordinateRequestPort,
                 deleteSystemCoordinateRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,
@@ -103,7 +103,7 @@ public class RequestMissingSystemCoordinatesUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createSystemCoordinateRequestPort, never()).create(any());
+        verify(createIfNotExistsSystemCoordinateRequestPort, never()).createIfNotExists(any());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class RequestMissingSystemCoordinatesUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort).send(any());
-        verify(createSystemCoordinateRequestPort).create(any());
+        verify(createIfNotExistsSystemCoordinateRequestPort).createIfNotExists(any());
     }
 
     @Test
@@ -164,6 +164,6 @@ public class RequestMissingSystemCoordinatesUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, times(2)).send(any());
-        verify(createSystemCoordinateRequestPort, times(2)).create(any());
+        verify(createIfNotExistsSystemCoordinateRequestPort, times(2)).createIfNotExists(any());
     }
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingSystemEliteIdUseCaseTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestMissingSystemEliteIdUseCaseTest.java
@@ -10,7 +10,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.DeleteSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.ExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.LoadAllSystemEliteIdRequestsPort;
@@ -56,7 +56,7 @@ public class RequestMissingSystemEliteIdUseCaseTest {
     @Mock
     private ExistsSystemEliteIdRequestPort existsSystemEliteIdRequestPort;
     @Mock
-    private CreateSystemEliteIdRequestPort createSystemEliteIdRequestPort;
+    private CreateIfNotExistsSystemEliteIdRequestPort createIfNotExistsSystemEliteIdRequestPort;
     @Mock
     private DeleteSystemEliteIdRequestPort deleteSystemEliteIdRequestPort;
     @Mock
@@ -77,7 +77,7 @@ public class RequestMissingSystemEliteIdUseCaseTest {
                 loadAllSystemEliteIdRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemEliteIdRequestPort,
-                createSystemEliteIdRequestPort,
+                createIfNotExistsSystemEliteIdRequestPort,
                 deleteSystemEliteIdRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,
@@ -103,7 +103,7 @@ public class RequestMissingSystemEliteIdUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createSystemEliteIdRequestPort, never()).create(any());
+        verify(createIfNotExistsSystemEliteIdRequestPort, never()).createIfNotExists(any());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class RequestMissingSystemEliteIdUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort).send(any());
-        verify(createSystemEliteIdRequestPort).create(any());
+        verify(createIfNotExistsSystemEliteIdRequestPort).createIfNotExists(any());
     }
 
     @Test
@@ -164,7 +164,7 @@ public class RequestMissingSystemEliteIdUseCaseTest {
         underTest.requestMissing();
 
         verify(sendKafkaMessagePort, times(2)).send(any());
-        verify(createSystemEliteIdRequestPort, times(2)).create(any());
+        verify(createIfNotExistsSystemEliteIdRequestPort, times(2)).createIfNotExists(any());
     }
 
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationArrivalDistanceServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationArrivalDistanceServiceTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateStationArrivalDistanceRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.CreateIfNotExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.DeleteStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.ExistsStationArrivalDistanceRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationarrivaldistancerequest.LoadAllStationArrivalDistanceRequestsPort;
@@ -60,7 +60,7 @@ public class RequestStationArrivalDistanceServiceTest {
     @Mock
     private ExistsStationArrivalDistanceRequestPort existsStationArrivalDistanceRequestPort;
     @Mock
-    private CreateStationArrivalDistanceRequestPort createStationArrivalDistanceRequestPort;
+    private CreateIfNotExistsStationArrivalDistanceRequestPort createIfNotExistsStationArrivalDistanceRequestPort;
     @Mock
     private UpdateStationPort updateStationPort;
     @Mock
@@ -91,7 +91,7 @@ public class RequestStationArrivalDistanceServiceTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationArrivalDistanceRequestPort,
-                createStationArrivalDistanceRequestPort,
+                createIfNotExistsStationArrivalDistanceRequestPort,
                 deleteStationArrivalDistanceRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -139,7 +139,7 @@ public class RequestStationArrivalDistanceServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationArrivalDistanceRequestPort, never()).create(anyString(), anyString());
+        verify(createIfNotExistsStationArrivalDistanceRequestPort, never()).createIfNotExists(anyString(), anyString());
     }
 
     @Test
@@ -184,6 +184,6 @@ public class RequestStationArrivalDistanceServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort).send(message);
-        verify(createStationArrivalDistanceRequestPort).create(systemName, stationName);
+        verify(createIfNotExistsStationArrivalDistanceRequestPort).createIfNotExists(systemName, stationName);
     }
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationArrivalDistanceServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationArrivalDistanceServiceTest.java
@@ -170,8 +170,7 @@ public class RequestStationArrivalDistanceServiceTest {
         JsonNode mockJsonNode = mock(JsonNode.class);
         String mockJsonString = "jsonString";
         Message message = new Message(Topic.Request.STATION_ARRIVAL_DISTANCE.getTopicName(), "jsonString");
-
-        when(existsStationArrivalDistanceRequestPort.exists(systemName, stationName)).thenReturn(false);
+        
         when(objectMapper.valueToTree(argThat(arg -> {
             if (arg instanceof StationDataRequest stationDataRequest) {
                 return systemName.equals(stationDataRequest.systemName()) && stationName.equals(stationDataRequest.stationName()) && Module.TRADE.equals(stationDataRequest.requestingModule());

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationLandingPadSizeServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationLandingPadSizeServiceTest.java
@@ -12,7 +12,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateStationLandingPadSizeRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.CreateIfNotExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.DeleteStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.ExistsStationLandingPadSizeRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationlandingpadsizerequest.LoadAllStationLandingPadSizeRequestsPort;
@@ -59,7 +59,7 @@ public class RequestStationLandingPadSizeServiceTest {
     @Mock
     private ExistsStationLandingPadSizeRequestPort existsStationLandingPadSizeRequestPort;
     @Mock
-    private CreateStationLandingPadSizeRequestPort createStationLandingPadSizeRequestPort;
+    private CreateIfNotExistsStationLandingPadSizeRequestPort createIfNotExistsStationLandingPadSizeRequestPort;
     @Mock
     private DeleteStationLandingPadSizeRequestPort deleteStationLandingPadSizeRequestPort;
     @Mock
@@ -94,7 +94,7 @@ public class RequestStationLandingPadSizeServiceTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationLandingPadSizeRequestPort,
-                createStationLandingPadSizeRequestPort,
+                createIfNotExistsStationLandingPadSizeRequestPort,
                 deleteStationLandingPadSizeRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -144,7 +144,7 @@ public class RequestStationLandingPadSizeServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationLandingPadSizeRequestPort, never()).create(anyString(), anyString());
+        verify(createIfNotExistsStationLandingPadSizeRequestPort, never()).createIfNotExists(anyString(), anyString());
     }
 
     @Test
@@ -190,6 +190,6 @@ public class RequestStationLandingPadSizeServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort).send(message);
-        verify(createStationLandingPadSizeRequestPort).create(systemName, stationName);
+        verify(createIfNotExistsStationLandingPadSizeRequestPort).createIfNotExists(systemName, stationName);
     }
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationPlanetaryServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationPlanetaryServiceTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateStationPlanetaryRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.CreateIfNotExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.DeleteStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.ExistsStationPlanetaryRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationplanetaryrequest.LoadAllStationPlanetaryRequestsPort;
@@ -55,7 +55,7 @@ public class RequestStationPlanetaryServiceTest {
     @Mock
     private ExistsStationPlanetaryRequestPort existsStationPlanetaryRequestPort;
     @Mock
-    private CreateStationPlanetaryRequestPort createStationPlanetaryRequestPort;
+    private CreateIfNotExistsStationPlanetaryRequestPort createIfNotExistsStationPlanetaryRequestPort;
     @Mock
     private DeleteStationPlanetaryRequestPort deleteStationPlanetaryRequestPort;
     @Mock
@@ -89,7 +89,7 @@ public class RequestStationPlanetaryServiceTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationPlanetaryRequestPort,
-                createStationPlanetaryRequestPort,
+                createIfNotExistsStationPlanetaryRequestPort,
                 deleteStationPlanetaryRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -150,6 +150,6 @@ public class RequestStationPlanetaryServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort).send(message);
-        verify(createStationPlanetaryRequestPort).create(systemName, stationName);
+        verify(createIfNotExistsStationPlanetaryRequestPort).createIfNotExists(systemName, stationName);
     }
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationRequireOdysseyServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestStationRequireOdysseyServiceTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.station.CreateOrLoadStationPort;
 import io.edpn.backend.trade.application.port.outgoing.station.LoadStationsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.station.UpdateStationPort;
-import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateStationRequireOdysseyRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.CreateIfNotExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.DeleteStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.ExistsStationRequireOdysseyRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.stationrequireodysseyrequest.LoadAllStationRequireOdysseyRequestsPort;
@@ -58,7 +58,7 @@ public class RequestStationRequireOdysseyServiceTest {
     @Mock
     private ExistsStationRequireOdysseyRequestPort existsStationRequireOdysseyRequestPort;
     @Mock
-    private CreateStationRequireOdysseyRequestPort createStationRequireOdysseyRequestPort;
+    private CreateIfNotExistsStationRequireOdysseyRequestPort createIfNotExistsStationRequireOdysseyRequestPort;
     @Mock
     private DeleteStationRequireOdysseyRequestPort deleteStationRequireOdysseyRequestPort;
     @Mock
@@ -91,7 +91,7 @@ public class RequestStationRequireOdysseyServiceTest {
                 createOrLoadSystemPort,
                 createOrLoadStationPort,
                 existsStationRequireOdysseyRequestPort,
-                createStationRequireOdysseyRequestPort,
+                createIfNotExistsStationRequireOdysseyRequestPort,
                 deleteStationRequireOdysseyRequestPort,
                 updateStationPort,
                 sendKafkaMessagePort,
@@ -139,7 +139,7 @@ public class RequestStationRequireOdysseyServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createStationRequireOdysseyRequestPort, never()).create(anyString(), anyString());
+        verify(createIfNotExistsStationRequireOdysseyRequestPort, never()).createIfNotExists(anyString(), anyString());
     }
 
     @Test
@@ -184,6 +184,6 @@ public class RequestStationRequireOdysseyServiceTest {
         underTest.request(station);
 
         verify(sendKafkaMessagePort).send(message);
-        verify(createStationRequireOdysseyRequestPort).create(systemName, stationName);
+        verify(createIfNotExistsStationRequireOdysseyRequestPort).createIfNotExists(systemName, stationName);
     }
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestSystemCoordinatesServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestSystemCoordinatesServiceTest.java
@@ -11,7 +11,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateSystemCoordinateRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.CreateIfNotExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.DeleteSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.ExistsSystemCoordinateRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemcoordinaterequest.LoadAllSystemCoordinateRequestsPort;
@@ -57,7 +57,7 @@ public class RequestSystemCoordinatesServiceTest {
     @Mock
     private ExistsSystemCoordinateRequestPort existsSystemCoordinateRequestPort;
     @Mock
-    private CreateSystemCoordinateRequestPort createSystemCoordinateRequestPort;
+    private CreateIfNotExistsSystemCoordinateRequestPort createIfNotExistsSystemCoordinateRequestPort;
     @Mock
     private DeleteSystemCoordinateRequestPort deleteSystemCoordinateRequestPort;
     @Mock
@@ -89,7 +89,7 @@ public class RequestSystemCoordinatesServiceTest {
                 loadAllSystemCoordinateRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemCoordinateRequestPort,
-                createSystemCoordinateRequestPort,
+                createIfNotExistsSystemCoordinateRequestPort,
                 deleteSystemCoordinateRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,
@@ -127,7 +127,7 @@ public class RequestSystemCoordinatesServiceTest {
         underTest.request(system);
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createSystemCoordinateRequestPort, never()).create(anyString());
+        verify(createIfNotExistsSystemCoordinateRequestPort, never()).createIfNotExists(anyString());
     }
 
     @Test
@@ -153,6 +153,6 @@ public class RequestSystemCoordinatesServiceTest {
         underTest.request(system);
 
         verify(sendKafkaMessagePort).send(message);
-        verify(createSystemCoordinateRequestPort).create(systemName);
+        verify(createIfNotExistsSystemCoordinateRequestPort).createIfNotExists(systemName);
     }
 }

--- a/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestSystemEliteIdServiceTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/application/service/RequestSystemEliteIdServiceTest.java
@@ -10,7 +10,7 @@ import io.edpn.backend.trade.application.port.outgoing.kafka.SendKafkaMessagePor
 import io.edpn.backend.trade.application.port.outgoing.system.CreateOrLoadSystemPort;
 import io.edpn.backend.trade.application.port.outgoing.system.LoadSystemsByFilterPort;
 import io.edpn.backend.trade.application.port.outgoing.system.UpdateSystemPort;
-import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateSystemEliteIdRequestPort;
+import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.CreateIfNotExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.DeleteSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.ExistsSystemEliteIdRequestPort;
 import io.edpn.backend.trade.application.port.outgoing.systemeliteidrequest.LoadAllSystemEliteIdRequestsPort;
@@ -55,7 +55,7 @@ public class RequestSystemEliteIdServiceTest {
     @Mock
     private ExistsSystemEliteIdRequestPort existsSystemEliteIdRequestPort;
     @Mock
-    private CreateSystemEliteIdRequestPort createSystemEliteIdRequestPort;
+    private CreateIfNotExistsSystemEliteIdRequestPort createIfNotExistsSystemEliteIdRequestPort;
     @Mock
     private DeleteSystemEliteIdRequestPort deleteSystemEliteIdRequestPort;
     @Mock
@@ -87,7 +87,7 @@ public class RequestSystemEliteIdServiceTest {
                 loadAllSystemEliteIdRequestsPort,
                 createOrLoadSystemPort,
                 existsSystemEliteIdRequestPort,
-                createSystemEliteIdRequestPort,
+                createIfNotExistsSystemEliteIdRequestPort,
                 deleteSystemEliteIdRequestPort,
                 updateSystemPort,
                 sendKafkaMessagePort,
@@ -125,7 +125,7 @@ public class RequestSystemEliteIdServiceTest {
         underTest.request(system);
 
         verify(sendKafkaMessagePort, never()).send(any());
-        verify(createSystemEliteIdRequestPort, never()).create(anyString());
+        verify(createIfNotExistsSystemEliteIdRequestPort, never()).createIfNotExists(anyString());
     }
 
     @Test
@@ -150,6 +150,6 @@ public class RequestSystemEliteIdServiceTest {
         underTest.request(system);
 
         verify(sendKafkaMessagePort).send(eq(new Message(Topic.Request.SYSTEM_ELITE_ID.getTopicName(), mockJsonString)));
-        verify(createSystemEliteIdRequestPort).create(systemName);
+        verify(createIfNotExistsSystemEliteIdRequestPort).createIfNotExists(systemName);
     }
 }


### PR DESCRIPTION
First revision to try and correct connection bug.

Trade module IMC was throwing primary key conflicts as duplicate requests were being logged to the table in certain parallel processing cases.

This was due to backend checking with databse before insert, in that turn around time multple requests were stacking for the same system/station combo. Updated to match exploration IMC and regular databases to createIfNotExists allowing the database to handle ON CONFLICT cases itself.

This was likely slowly consuming the full connection pool which locked the rest of the system from continuing to interact with the database. This change is a needed fix regardless of whether its the true root causes of the larger issue.