### PR TITLE
Database ports listen only on localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - "trademodule_postgis:/var/lib/postgresql/data"
     ports:
-      - "27730:5432"
+      - "127.0.0.1:27730:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d trademodule -U edpn_trademodule"]
       interval: 10s
@@ -60,7 +60,7 @@ services:
     volumes:
       - "explorationmodule_postgis:/var/lib/postgresql/data"
     ports:
-      - "28302:5432"
+      - "127.0.0.1:28302:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d explorationmodule -U edpn_explorationmodule"]
       interval: 10s


### PR DESCRIPTION
This change just makes the database ports for testing/dev access only accessible on localhost/127.0.0.1. This was also introduced in #149 but I fudged it by making some other changes. Reintroducing here.

Related to #138 