### PR TITLE
138 Part 2 Database Ports To Listen Locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - "trademodule_postgis:/var/lib/postgresql/data"
     ports:
-      - "27730:5432"
+      - "127.0.0.1:27730:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d trademodule -U edpn_trademodule"]
       interval: 10s
@@ -60,7 +60,7 @@ services:
     volumes:
       - "explorationmodule_postgis:/var/lib/postgresql/data"
     ports:
-      - "28302:5432"
+      - "127.0.0.1:28302:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d explorationmodule -U edpn_explorationmodule"]
       interval: 10s


### PR DESCRIPTION
Just appending local route to docker-compose.yml so databases can only be reached internally.