### PR TITLE
151-2 Add additional indexes to optimize trade query

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     ## TODO: Tag this image locally
     image: "postgis/postgis:15-3.3-alpine"
     restart: on-failure
+    shm_size: '1gb' # needed to allow vacuum
     env_file:
       - env/${ENVIRONMENT}/.env_trademodule
     volumes:
@@ -55,6 +56,7 @@ services:
     ## TODO: Tag this image locally
     image: "postgis/postgis:15-3.3-alpine"
     restart: on-failure
+    shm_size: '1gb' # needed to allow vacuum
     env_file:
       - env/${ENVIRONMENT}/.env_explorationmodule
     volumes:

--- a/trade-module/src/main/resources/db/trademodule/changelog/add_commodity_cover_index.xml
+++ b/trade-module/src/main/resources/db/trademodule/changelog/add_commodity_cover_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add_commodity_cover_index" author="daniel-j-mason">
+        <sql>
+            create index commodity_id_is_rare_index
+                on commodity (id, is_rare) include (display_name);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/trade-module/src/main/resources/db/trademodule/changelog/add_latest_market_datum_cover_indexes.xml
+++ b/trade-module/src/main/resources/db/trademodule/changelog/add_latest_market_datum_cover_indexes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add_commodity_cover_indexes" author="daniel-j-mason">
+        <createIndex tableName="latest_market_datum" indexName="latest_market_datum_compound_buy_market_index">
+            <column>station_id</column>
+            <column>commodity_id</column>
+            <column>timestamp</column>
+            <column>buy_price</column>
+            <column>stock</column>
+        </createIndex>
+        <createIndex tableName="latest_market_datum" indexName="latest_market_datum_compound_sell_market_index">
+            <column>station_id</column>
+            <column>commodity_id</column>
+            <column>timestamp</column>
+            <column>sell_price</column>
+            <column>demand</column>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/trade-module/src/main/resources/db/trademodule/changelog/trademodule-changelog.xml
+++ b/trade-module/src/main/resources/db/trademodule/changelog/trademodule-changelog.xml
@@ -34,6 +34,8 @@
     <include file="/db/trademodule/changelog/add_unique_index_commodity_name.xml"/>
     <include file="/db/trademodule/changelog/add_latest_market_datum_demand_supply_price_indexes.xml"/>
     <include file="/db/trademodule/changelog/add_station_arrival_distance_index.xml"/>
+    <include file="/db/trademodule/changelog/add_commodity_cover_index.xml"/>
+    <include file="/db/trademodule/changelog/add_latest_market_datum_cover_indexes.xml"/>
 
     <!-- views always last as they might depend on new columns -->
     <include file="/db/trademodule/changelog/create_validated_commodity_view.xml"/>


### PR DESCRIPTION
add share mem option to docker compose to allow vacuum to run
add cover indexes to significantly speed up trade query based on analyzing postgres optimizer plan