### PR TITLE
Change maxLandingPadSize type to integer

### DIFF
--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/entity/MybatisStationEntity.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/entity/MybatisStationEntity.java
@@ -28,7 +28,7 @@ public class MybatisStationEntity {
     private Boolean planetary;
     private Boolean requireOdyssey;
     private Boolean fleetCarrier;
-    private String maxLandingPadSize;
+    private int maxLandingPadSize;
     private LocalDateTime marketUpdatedAt;
     @Builder.Default
     private List<MybatisMarketDatumEntity> marketData = new ArrayList<>();

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/entity/mapper/MybatisStationEntityMapper.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/entity/mapper/MybatisStationEntityMapper.java
@@ -23,7 +23,7 @@ public class MybatisStationEntityMapper {
                 mybatisStationEntity.getPlanetary(),
                 mybatisStationEntity.getRequireOdyssey(),
                 mybatisStationEntity.getFleetCarrier(),
-                LandingPadSize.valueOf(mybatisStationEntity.getMaxLandingPadSize()),
+                LandingPadSize.fromInteger(mybatisStationEntity.getMaxLandingPadSize()),
                 mybatisStationEntity.getMarketUpdatedAt(),
                 mybatisStationEntity.getMarketData().stream().map(mybatisMarketDatumEntityMapper::map).toList()
         );
@@ -39,7 +39,7 @@ public class MybatisStationEntityMapper {
                 .planetary(station.planetary())
                 .requireOdyssey(station.requireOdyssey())
                 .fleetCarrier(station.fleetCarrier())
-                .maxLandingPadSize(Optional.ofNullable(station.maxLandingPadSize()).map(LandingPadSize::name).orElse(LandingPadSize.UNKNOWN.name()))
+                .maxLandingPadSize(Optional.ofNullable(station.maxLandingPadSize()).map(LandingPadSize::value).orElse(LandingPadSize.UNKNOWN.value()))
                 .marketUpdatedAt(station.marketUpdatedAt())
                 .marketData(station.marketData().stream().map(mybatisMarketDatumEntityMapper::map).toList())
                 .build();

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/filter/MybatisLocateCommodityFilter.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/filter/MybatisLocateCommodityFilter.java
@@ -24,7 +24,7 @@ public class MybatisLocateCommodityFilter {
     private Boolean includePlanetary;
     private Boolean includeOdyssey;
     private Boolean includeFleetCarriers;
-    private String maxLandingPadSize;
+    private Integer maxLandingPadSize;
     private Long minSupply;
     private Long minDemand;
 }

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/filter/mapper/MybatisLocateCommodityFilterMapper.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/filter/mapper/MybatisLocateCommodityFilterMapper.java
@@ -1,6 +1,9 @@
 package io.edpn.backend.trade.adapter.persistence.filter.mapper;
 
 import io.edpn.backend.trade.adapter.persistence.filter.MybatisLocateCommodityFilter;
+import io.edpn.backend.trade.application.domain.LandingPadSize;
+
+import java.util.Optional;
 
 public class MybatisLocateCommodityFilterMapper {
 
@@ -13,7 +16,7 @@ public class MybatisLocateCommodityFilterMapper {
                 .includePlanetary(locateCommodityFilter.getIncludePlanetary())
                 .includeOdyssey(locateCommodityFilter.getIncludeOdyssey())
                 .includeFleetCarriers(locateCommodityFilter.getIncludeFleetCarriers())
-                .maxLandingPadSize(String.valueOf(locateCommodityFilter.getMaxLandingPadSize()))
+                .maxLandingPadSize(Optional.ofNullable(locateCommodityFilter.getMaxLandingPadSize()).map(LandingPadSize::value).orElse(null))
                 .minSupply(locateCommodityFilter.getMinSupply())
                 .minDemand(locateCommodityFilter.getMinDemand())
                 .build();

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisLocateCommodityRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisLocateCommodityRepository.java
@@ -32,8 +32,7 @@ public interface MybatisLocateCommodityRepository {
             <if test='!includeFleetCarriers'>AND fleet_carrier = false </if>
             AND stock >= #{minSupply}
             AND demand >= #{minDemand}
-            <if test='maxLandingPadSize == "LARGE"'>AND max_landing_pad_size = 'LARGE'</if>
-            <if test='maxLandingPadSize == "MEDIUM"'>AND max_landing_pad_size IN ('MEDIUM', 'LARGE')</if>
+            AND max_landing_pad_size >= #{maxLandingPadSize}
             ORDER BY distance
             </script>"""
     )

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationRepository.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/persistence/repository/MybatisStationRepository.java
@@ -30,7 +30,7 @@ public interface MybatisStationRepository {
             @Result(property = "planetary", column = "planetary", javaType = boolean.class),
             @Result(property = "requireOdyssey", column = "require_odyssey", javaType = boolean.class),
             @Result(property = "fleetCarrier", column = "fleet_carrier", javaType = boolean.class),
-            @Result(property = "maxLandingPadSize", column = "max_landing_pad_size", javaType = String.class),
+            @Result(property = "maxLandingPadSize", column = "max_landing_pad_size", javaType = Integer.class),
             @Result(property = "marketUpdatedAt", column = "market_updated_at", javaType = LocalDateTime.class)
     })
     Optional<MybatisStationEntity> findById(@Param("id") UUID id);
@@ -45,7 +45,10 @@ public interface MybatisStationRepository {
             SELECT * FROM station
             WHERE 1 = 1
             <if test='hasRequiredOdyssey != null'>AND require_odyssey IS NULL != #{hasRequiredOdyssey}</if>
-            <if test='hasLandingPadSize != null'>AND max_landing_pad_size IS NULL != #{hasLandingPadSize}</if>
+            <if test='hasLandingPadSize != null'>AND (
+                            max_landing_pad_size IS NULL != #{hasLandingPadSize} OR
+                            (max_landing_pad_size = -1) !=  #{hasLandingPadSize}
+            </if>
             <if test='hasPlanetary != null'>AND planetary IS NULL != #{hasPlanetary}</if>
             <if test='hasArrivalDistance != null'>AND arrival_distance IS NULL != #{hasArrivalDistance}</if>
             </script>

--- a/trade-module/src/main/java/io/edpn/backend/trade/adapter/web/dto/filter/mapper/RestLocateCommodityFilterDtoMapper.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/adapter/web/dto/filter/mapper/RestLocateCommodityFilterDtoMapper.java
@@ -4,6 +4,8 @@ import io.edpn.backend.trade.adapter.web.dto.filter.RestLocateCommodityFilterDto
 import io.edpn.backend.trade.application.domain.LandingPadSize;
 import io.edpn.backend.trade.application.domain.filter.LocateCommodityFilter;
 
+import java.util.Optional;
+
 public class RestLocateCommodityFilterDtoMapper {
     public LocateCommodityFilter map(RestLocateCommodityFilterDto restLocateCommodityFilterDto) {
         return new LocateCommodityFilter(
@@ -14,7 +16,7 @@ public class RestLocateCommodityFilterDtoMapper {
                 restLocateCommodityFilterDto.includePlanetary(),
                 restLocateCommodityFilterDto.includeOdyssey(),
                 restLocateCommodityFilterDto.includeFleetCarriers(),
-                LandingPadSize.valueOf(restLocateCommodityFilterDto.maxLandingPadSize()),
+                Optional.ofNullable(restLocateCommodityFilterDto.maxLandingPadSize()).map(LandingPadSize::valueOf).orElse(LandingPadSize.UNKNOWN),
                 restLocateCommodityFilterDto.minSupply(),
                 restLocateCommodityFilterDto.minDemand()
         );

--- a/trade-module/src/main/java/io/edpn/backend/trade/application/domain/LandingPadSize.java
+++ b/trade-module/src/main/java/io/edpn/backend/trade/application/domain/LandingPadSize.java
@@ -1,8 +1,30 @@
 package io.edpn.backend.trade.application.domain;
 
+import java.util.NoSuchElementException;
+
 public enum LandingPadSize {
-    UNKNOWN,
-    SMALL,
-    MEDIUM,
-    LARGE
+    UNKNOWN(-1),
+    SMALL(100),
+    MEDIUM(200),
+    LARGE(300);
+
+    private final int value;
+
+    LandingPadSize(int value) {
+        this.value = value;
+    }
+
+    public static LandingPadSize fromInteger(int x) {
+        for (LandingPadSize size : LandingPadSize.values()) {
+            if (size.value == x) {
+                return size;
+            }
+        }
+
+        throw new NoSuchElementException("integer value %d is not mapped to a landing pad size".formatted(x));
+    }
+
+    public int value() {
+        return value;
+    }
 }

--- a/trade-module/src/main/resources/db/trademodule/changelog/change_max_landing_pad_size_to_numeral.xml
+++ b/trade-module/src/main/resources/db/trademodule/changelog/change_max_landing_pad_size_to_numeral.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="change_max_landing_pad_size_to_numeral_add_temp_column" author="pveeckhout">
+        <addColumn tableName="station">
+            <column name="max_landing_pad_size_temp" type="integer"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="change_max_landing_pad_size_to_numeral_fill_temp_column" author="pveeckhout">
+        <sql>
+            UPDATE station SET max_landing_pad_size_temp = CASE
+                                                               WHEN max_landing_pad_size = 'SMALL' THEN 100
+                                                               WHEN max_landing_pad_size = 'MEDIUM' THEN 200
+                                                               WHEN max_landing_pad_size = 'LARGE' THEN 300
+                                                               ELSE -1 -- Handling any unexpected values, nulls and UNKNOWN
+                END
+        </sql>
+    </changeSet>
+
+    <changeSet id="change_max_landing_pad_size_to_numeral_drop_old_column" author="pveeckhout">
+        <dropColumn columnName="max_landing_pad_size" tableName="station"/>
+    </changeSet>
+
+    <changeSet id="change_max_landing_pad_size_to_numeral_rename_column" author="pveeckhout">
+        <renameColumn oldColumnName="max_landing_pad_size_temp" newColumnName="max_landing_pad_size" tableName="station"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/trade-module/src/main/resources/db/trademodule/changelog/trademodule-changelog.xml
+++ b/trade-module/src/main/resources/db/trademodule/changelog/trademodule-changelog.xml
@@ -38,6 +38,7 @@
     <include file="/db/trademodule/changelog/fill_commodity_combined_table.xml"/>
     <include file="/db/trademodule/changelog/add_commodity_cover_index.xml"/>
     <include file="/db/trademodule/changelog/add_latest_market_datum_cover_indexes.xml"/>
+    <include file="/db/trademodule/changelog/change_max_landing_pad_size_to_numeral.xml"/>
 
     <!-- views always last as they might depend on new columns -->
     <include file="/db/trademodule/changelog/create_validated_commodity_view.xml"/>

--- a/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/entity/mapper/MybatisStationEntityMapperTest.java
+++ b/trade-module/src/test/java/io/edpn/backend/trade/adapter/persistence/entity/mapper/MybatisStationEntityMapperTest.java
@@ -54,7 +54,7 @@ class MybatisStationEntityMapperTest {
         Boolean planetary = true;
         Boolean requireOdyssey = true;
         Boolean fleetCarrier = true;
-        String maxLandingPadSize = "LARGE";
+        int maxLandingPadSize = 300;
         LocalDateTime marketUpdatedAt = LocalDateTime.now();
 
         MybatisStationEntity entity = MybatisStationEntity.builder()
@@ -72,7 +72,7 @@ class MybatisStationEntityMapperTest {
                 .build();
 
         when(mybatisSystemEntityMapper.map(entity.getSystem())).thenReturn(mockSystem);
-        when(mybatisMarketDatumEntityMapper.map(entity.getMarketData().get(0))).thenReturn(mockMarketDatum);
+        when(mybatisMarketDatumEntityMapper.map(entity.getMarketData().getFirst())).thenReturn(mockMarketDatum);
 
         Station domainObject = underTest.map(entity);
 
@@ -87,7 +87,7 @@ class MybatisStationEntityMapperTest {
         assertThat(domainObject.marketUpdatedAt(), is(marketUpdatedAt));
 
         verify(mybatisSystemEntityMapper, times(1)).map(entity.getSystem());
-        verify(mybatisMarketDatumEntityMapper, times(1)).map(entity.getMarketData().get(0));
+        verify(mybatisMarketDatumEntityMapper, times(1)).map(entity.getMarketData().getFirst());
     }
 
     @Test
@@ -122,7 +122,7 @@ class MybatisStationEntityMapperTest {
         );
 
         when(mybatisSystemEntityMapper.map(domainObject.system())).thenReturn(mockMybatisSystemEntity);
-        when(mybatisMarketDatumEntityMapper.map(domainObject.marketData().get(0))).thenReturn(mockMybatisMarketDatumEntity);
+        when(mybatisMarketDatumEntityMapper.map(domainObject.marketData().getFirst())).thenReturn(mockMybatisMarketDatumEntity);
 
         MybatisStationEntity entity = underTest.map(domainObject);
 
@@ -133,10 +133,10 @@ class MybatisStationEntityMapperTest {
         assertThat(entity.getPlanetary(), is(planetary));
         assertThat(entity.getRequireOdyssey(), is(requireOdyssey));
         assertThat(entity.getFleetCarrier(), is(fleetCarrier));
-        assertThat(entity.getMaxLandingPadSize(), is(maxLandingPadSize));
+        assertThat(entity.getMaxLandingPadSize(), is(300));
         assertThat(entity.getMarketUpdatedAt(), is(marketUpdatedAt));
 
         verify(mybatisSystemEntityMapper, times(1)).map(domainObject.system());
-        verify(mybatisMarketDatumEntityMapper, times(1)).map(domainObject.marketData().get(0));
+        verify(mybatisMarketDatumEntityMapper, times(1)).map(domainObject.marketData().getFirst());
     }
 }


### PR DESCRIPTION
Modified maxLandingPadSize property across the application to use integer values instead of string. This includes changes in the database, entity classes, and filter classes. The update not only simplifies comparisons but should improve application performance on station queries.