### PR TITLE
174-increase-system-name-search-speed

### DIFF
--- a/exploration-module/src/main/resources/db/explorationmodule/changelog/add_system_name_trigram_index.xml
+++ b/exploration-module/src/main/resources/db/explorationmodule/changelog/add_system_name_trigram_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add_system_name_trigram_index" author="daniel-j-mason">
+        <sql>
+            CREATE EXTENSION IF NOT EXISTS pg_trgm;
+            CREATE index system_name_gin_trgm_idx ON system using gin(name gin_trgm_ops)
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/exploration-module/src/main/resources/db/explorationmodule/changelog/explorationmodule-changelog.xml
+++ b/exploration-module/src/main/resources/db/explorationmodule/changelog/explorationmodule-changelog.xml
@@ -23,6 +23,7 @@
     <include file="db/explorationmodule/changelog/create_station_maxlandingpadsize_data_request_table.xml"/>
     <include file="db/explorationmodule/changelog/create_station_table.xml"/>
     <include file="db/explorationmodule/changelog/create_station_arrivaldistance_data_request_table.xml"/>
+    <include file="db/explorationmodule/changelog/add_system_name_trigram_index.xml"/>
 
     <!-- views always last as they might depend on new columns -->
 


### PR DESCRIPTION
Applied GIN trigram index to dramatically increase partial name search speed

query time dropped to under 4ms

closes 174