### PR TITLE
#176 - Update allowed origin in CORS configuration

### DIFF
--- a/boot/src/main/java/io/edpn/backend/configuration/WebSecurityConfig.java
+++ b/boot/src/main/java/io/edpn/backend/configuration/WebSecurityConfig.java
@@ -25,7 +25,7 @@ public class WebSecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOrigin("http://localhost:3000");
-        configuration.addAllowedOrigin("http://*.edpn.io*");
+        configuration.addAllowedOrigin("https://*.edpn.io*");
         configuration.addAllowedMethod(CorsConfiguration.ALL);
         configuration.addAllowedHeader(CorsConfiguration.ALL);
         

--- a/boot/src/main/java/io/edpn/backend/configuration/WebSecurityConfig.java
+++ b/boot/src/main/java/io/edpn/backend/configuration/WebSecurityConfig.java
@@ -24,8 +24,10 @@ public class WebSecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("https://localhost:3000");
         configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedOrigin("https://*.edpn.io*");
+        configuration.addAllowedOrigin("http://*.edpn.io*");
         configuration.addAllowedMethod(CorsConfiguration.ALL);
         configuration.addAllowedHeader(CorsConfiguration.ALL);
         


### PR DESCRIPTION
The commit changes the allowed origin in the CORS configuration from "http" to "https" for the "edpn.io" domain. This fortifies the security of the application by ensuring communications are made over a secure connection.

closes #176 